### PR TITLE
Ensure MOTD buffer is copied safely

### DIFF
--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -554,7 +554,7 @@ void G_LoadMOTD() {
 	if (f != NULL) {
 		char *buffer = nullptr;
 		size_t length;
-		size_t read_length;
+		size_t read_length = 0;
 
 		fseek(f, 0, SEEK_END);
 		length = ftell(f);
@@ -566,25 +566,33 @@ void G_LoadMOTD() {
 		}
 		if (valid) {
 			buffer = (char *)gi.TagMalloc(length + 1, '\0');
-			if (length) {
-				read_length = fread(buffer, 1, length, f);
+			if (buffer) {
+				if (length) {
+					read_length = fread(buffer, 1, length, f);
 
-				if (length != read_length) {
-					gi.Com_PrintFmt("{}: MoTD file read error: \"{}\"\n", __FUNCTION__, name);
-					valid = false;
+					if (length != read_length) {
+						gi.Com_PrintFmt("{}: MoTD file read error: \"{}\"\n", __FUNCTION__, name);
+						valid = false;
+					}
 				}
+			} else {
+				valid = false;
 			}
 		}
 		fclose(f);
 		
 		if (valid) {
-			game.motd = (const char *)buffer;
+			buffer[length ? length : 0] = '\0';
+			game.motd.assign(buffer, length);
 			game.motd_mod_count++;
 			if (g_verbose->integer)
 				gi.Com_PrintFmt("{}: MotD file verified and loaded: \"{}\"\n", __FUNCTION__, name);
 		} else {
 			gi.Com_PrintFmt("{}: MotD file load error for \"{}\", discarding.\n", __FUNCTION__, name);
 		}
+
+		if (buffer)
+			gi.TagFree(buffer);
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure the MOTD buffer is null-terminated after reading the file
- copy the MOTD contents into the std::string and free the temporary buffer once done

## Testing
- cmake -S . -B build *(fails: The source directory "/workspace/muffmode" does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68df16fc6ab483289f39b1a2060b087d