### PR TITLE
Sync team reset with pending gametype

### DIFF
--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -761,10 +761,12 @@ void GT_Changes() {
 
 	//gi.Com_PrintFmt("GAMETYPE = {}\n", (int)gt);
 	
-	if (gt_teams_on != Teams()) {
-		team_reset = true;
-		gt_teams_on = Teams();
-	}
+        bool teams_enabled = (_gt[(int)gt] & GTF_TEAMS) != 0;
+
+        if (gt_teams_on != teams_enabled) {
+                gt_teams_on = teams_enabled;
+                team_reset = true;
+        }
 
 	if (team_reset) {
 		// move all to spectator first


### PR DESCRIPTION
## Summary
- derive the team-enabled state from the pending gametype change
- ensure `gt_teams_on` tracks the pending state before triggering resets
- rely on the pending state for deciding when to freeze and reassign players

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df193ae1dc83289ce0452682bd2bd3