### PR TITLE
Document strike, rr, lms, and ball gametypes

### DIFF
--- a/docs/progress.txt
+++ b/docs/progress.txt
@@ -15,7 +15,8 @@ The Big Gametype and Mapping Update!
 				7. CaptureStrike
 				8. Red Rover
 				9. Last Man Standing
-				10. Horde
+                                10. Horde
+                                11. ProBall
 		- Obsolete gametype cvars such as 'duel' have been removed. For compatibility purposes, all that remain are 'ctf' and 'teamplay' but these are overridden by g_gametype.
 		- New command for admins: "gametype [gametype_name]" changes the gametype to the specified name, effectively the same as callvote gametype.
 
@@ -25,7 +26,8 @@ The Big Gametype and Mapping Update!
 	- CaptureStrike: A Threewave classic, combines Clan Arena, CTF and Counter Strike. Teams take turns attacking or defending and battle until one team is dead, or the attacking team captures the flag.
 	- Red Rover: Another Rocket Arena mode, a unique full arsenal arena mode where players switch teams on death. Once there are no players remaining on a team - or a player hits the score limit, the player with the highest score wins.
 	- Freeze Tag
-	- Last Man Standing
+       - Last Man Standing
+       - ProBall: Fast-paced arena soccer featuring grapple-fueled movement and explosive goals.
 	
 * NEW ADMIN CVARS:
 	- g_ruleset: gameplay rules (default 2):

--- a/src/g_cmds.cpp
+++ b/src/g_cmds.cpp
@@ -2626,7 +2626,7 @@ vcmds_t vote_cmds[] = {
 	{"map",					Vote_Val_Map,			Vote_Pass_Map,			1,		2,	"[mapname]",						"changes to the specified map"},
 	{"nextmap",				Vote_Val_None,			Vote_Pass_NextMap,		2,		1,	"",									"move to the next map in the rotation"},
 	{"restart",				Vote_Val_None,			Vote_Pass_RestartMatch,	4,		1,	"",									"restarts the current match"},
-	{"gametype",			Vote_Val_Gametype,		Vote_Pass_Gametype,		8,		2,	"<ffa|duel|tdm|ctf|ca|ft|horde>",	"changes the current gametype"},
+	{"gametype",			Vote_Val_Gametype,		Vote_Pass_Gametype,		8,		2,	"<cmp|ffa|duel|tdm|ctf|ca|ft|strike|rr|lms|horde|ball>",	"changes the current gametype"},
 	{"timelimit",			Vote_Val_Timelimit,		Vote_Pass_Timelimit,	16,		2,	"<0..$>",							"alters the match time limit, 0 for no time limit"},
 	{"scorelimit",			Vote_Val_Scorelimit,	Vote_Pass_Scorelimit,	32,		2,	"<0..$>",							"alters the match score limit, 0 for no score limit"},
 	{"shuffle",				Vote_Val_ShuffleTeams,	Vote_Pass_ShuffleTeams,	64,		2,	"",									"shuffles teams"},
@@ -3149,7 +3149,7 @@ static void Cmd_Gametype_f(gentity_t *ent) {
 		return;
 
 	if (gi.argc() < 2) {
-		gi.LocClient_Print(ent, PRINT_HIGH, "Usage: {} <ffa|duel|tdm|ctf|ca|ft|horde>\nChanges current gametype. Current gametype is {} ({}).\n", gi.argv(0), gt_long_name[g_gametype->integer], g_gametype->integer);
+		gi.LocClient_Print(ent, PRINT_HIGH, "Usage: {} <cmp|ffa|duel|tdm|ctf|ca|ft|strike|rr|lms|horde|ball>\nChanges current gametype. Current gametype is {} ({}).\n", gi.argv(0), gt_long_name[g_gametype->integer], g_gametype->integer);
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- expand the admin gametype command usage string and vote prompt to list every supported gametype keyword
- update the gametype listing in progress documentation to include the new ProBall mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df193c52ec83289da8962004c470e3