### PR TITLE
Improve gametype alias handling and legacy cvar synchronization

### DIFF
--- a/src/g_cmds.cpp
+++ b/src/g_cmds.cpp
@@ -2472,12 +2472,19 @@ void Vote_Pass_Gametype() {
 }
 
 static bool Vote_Val_Gametype(gentity_t *ent) {
-	if (GT_IndexFromString(gi.argv(2)) == gametype_t::GT_NONE) {
-		gi.LocClient_Print(ent, PRINT_HIGH, "Invalid gametype.\n");
-		return false;
-	}
+        gametype_t gt = GT_IndexFromString(gi.argv(2));
 
-	return true;
+        if (gt == gametype_t::GT_NONE) {
+                gi.LocClient_Print(ent, PRINT_HIGH, "Invalid gametype.\nValid options: {}.\n", GT_CallvoteList());
+                return false;
+        }
+
+        if (static_cast<int>(gt) == g_gametype->integer) {
+                gi.LocClient_Print(ent, PRINT_HIGH, "Gametype is already set to {}.\n", gt_long_name[g_gametype->integer]);
+                return false;
+        }
+
+        return true;
 }
 
 static void Vote_Pass_Ruleset() {
@@ -2626,7 +2633,7 @@ vcmds_t vote_cmds[] = {
 	{"map",					Vote_Val_Map,			Vote_Pass_Map,			1,		2,	"[mapname]",						"changes to the specified map"},
 	{"nextmap",				Vote_Val_None,			Vote_Pass_NextMap,		2,		1,	"",									"move to the next map in the rotation"},
 	{"restart",				Vote_Val_None,			Vote_Pass_RestartMatch,	4,		1,	"",									"restarts the current match"},
-	{"gametype",			Vote_Val_Gametype,		Vote_Pass_Gametype,		8,		2,	"<ffa|duel|tdm|ctf|ca|ft|horde>",	"changes the current gametype"},
+	{"gametype",			Vote_Val_Gametype,		Vote_Pass_Gametype,		8,		2,	GT_CallvoteArgs(),	"changes the current gametype"},
 	{"timelimit",			Vote_Val_Timelimit,		Vote_Pass_Timelimit,	16,		2,	"<0..$>",							"alters the match time limit, 0 for no time limit"},
 	{"scorelimit",			Vote_Val_Scorelimit,	Vote_Pass_Scorelimit,	32,		2,	"<0..$>",							"alters the match score limit, 0 for no score limit"},
 	{"shuffle",				Vote_Val_ShuffleTeams,	Vote_Pass_ShuffleTeams,	64,		2,	"",									"shuffles teams"},
@@ -3148,18 +3155,23 @@ static void Cmd_Gametype_f(gentity_t *ent) {
 	if (!deathmatch->integer)
 		return;
 
-	if (gi.argc() < 2) {
-		gi.LocClient_Print(ent, PRINT_HIGH, "Usage: {} <ffa|duel|tdm|ctf|ca|ft|horde>\nChanges current gametype. Current gametype is {} ({}).\n", gi.argv(0), gt_long_name[g_gametype->integer], g_gametype->integer);
-		return;
-	}
+        if (gi.argc() < 2) {
+                gi.LocClient_Print(ent, PRINT_HIGH, "Usage: {} {}\nChanges current gametype. Current gametype is {} ({}).\n", gi.argv(0), GT_CallvoteArgs(), gt_long_name[g_gametype->integer], g_gametype->integer);
+                return;
+        }
 
-	gametype_t gt = GT_IndexFromString(gi.argv(1));
-	if (gt == GT_NONE) {
-		gi.LocClient_Print(ent, PRINT_HIGH, "Invalid gametype.\n");
-		return;
-	}
+        gametype_t gt = GT_IndexFromString(gi.argv(1));
+        if (gt == GT_NONE) {
+                gi.LocClient_Print(ent, PRINT_HIGH, "Invalid gametype.\nValid options: {}.\n", GT_CallvoteList());
+                return;
+        }
 
-	ChangeGametype(gt);
+        if (static_cast<int>(gt) == g_gametype->integer) {
+                gi.LocClient_Print(ent, PRINT_HIGH, "Gametype is already set to {}.\n", gt_long_name[g_gametype->integer]);
+                return;
+        }
+
+        ChangeGametype(gt);
 }
 
 /*

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -244,6 +244,10 @@ extern int _gt[GT_NUM_GAMETYPES];
 #define GT( x ) g_gametype->integer == (int)(x)
 #define notGT( x ) g_gametype->integer != (int)(x)
 
+inline int GT_Flags(gametype_t gt) {
+        return _gt[static_cast<size_t>(gt)];
+}
+
 constexpr const char *gt_short_name[GT_NUM_GAMETYPES] = {
 	"cmp",
 	"ffa",
@@ -273,19 +277,23 @@ constexpr const char *gt_short_name_upper[GT_NUM_GAMETYPES] = {
 	"BALL",
 };
 constexpr const char *gt_long_name[GT_NUM_GAMETYPES] = {
-	"Campaign",
-	"Deathmatch",
-	"Duel",
-	"Team Deathmatch",
-	"Capture the Flag",
-	"Clan Arena",
-	"Freeze Tag",
-	"CaptureStrike",
-	"Red Rover",
-	"Last Man Standing",
-	"Horde Mode",
-	"ProBall"
+        "Campaign",
+        "Deathmatch",
+        "Duel",
+        "Team Deathmatch",
+        "Capture the Flag",
+        "Clan Arena",
+        "Freeze Tag",
+        "CaptureStrike",
+        "Red Rover",
+        "Last Man Standing",
+        "Horde Mode",
+        "ProBall"
 };
+
+const char *GT_CommandName(gametype_t gt);
+const char *GT_CallvoteList();
+const char *GT_CallvoteArgs();
 
 enum monflags_t {
 	MF_NONE		= 0x00,


### PR DESCRIPTION
## Summary
- add canonical gametype aliases and helper accessors for command and vote usage
- tighten gametype vote/admin validation to show dynamic option lists and avoid redundant changes
- centralize legacy teamplay/ctf cvar synchronization based on gametype metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df1a87213c832899da9a6f2cc26726