### PR TITLE
Implement modern Freeze Tag mechanics

### DIFF
--- a/src/g_local.h
+++ b/src/g_local.h
@@ -3192,6 +3192,11 @@ void Round_End();
 void SetIntermissionPoint(void);
 void FindIntermissionPoint(void);
 void CalculateRanks();
+
+bool Freeze_IsFrozen(const gentity_t *ent);
+void Freeze_OnPlayerKilled(gentity_t *victim, gentity_t *attacker);
+void Freeze_UpdatePlayer(gentity_t *ent);
+void Freeze_ResetClient(gentity_t *ent);
 void CheckDMExitRules();
 int GT_ScoreLimit();
 const char *GT_ScoreLimitString();
@@ -3763,11 +3768,12 @@ struct gclient_t {
 	gtime_t	 last_firing_time;
 
 	bool		eliminated;
+	bool		freeze_thawing;
 /*freeze*/
 	gentity_t		*viewed;
-	float		thaw_time;
-	float		frozen_time;
-	float		moan_time;
+	gtime_t	thaw_time;
+	gtime_t	frozen_time;
+	gtime_t	moan_time;
 /*freeze*/
 
 	bool		ready_to_exit;

--- a/src/p_view.cpp
+++ b/src/p_view.cpp
@@ -1266,15 +1266,18 @@ void ClientEndServerFrame(gentity_t *ent) {
 	P_ForceFogTransition(ent, false);
 
 	// check goals
-	G_PlayerNotifyGoal(ent);
+        G_PlayerNotifyGoal(ent);
 
-	// mega health
-	P_RunMegaHealth(ent);
+        // mega health
+        P_RunMegaHealth(ent);
 
-	// vampiric damage expiration
-	// don't expire if only 1 player in the match
-	if (g_vampiric_damage->integer && ClientIsPlaying(ent->client) && !IsCombatDisabled() && (ent->health > g_vampiric_exp_min->integer)) {
-		if (level.num_playing_clients > 1 && level.time > ent->client->vampire_expiretime) {
+        if (GT(GT_FREEZE))
+                Freeze_UpdatePlayer(ent);
+
+        // vampiric damage expiration
+        // don't expire if only 1 player in the match
+        if (g_vampiric_damage->integer && ClientIsPlaying(ent->client) && !IsCombatDisabled() && (ent->health > g_vampiric_exp_min->integer)) {
+                if (level.num_playing_clients > 1 && level.time > ent->client->vampire_expiretime) {
 			int quantity = floor((ent->health - 1) / ent->max_health) + 1;
 			ent->health -= quantity;
 			ent->client->vampire_expiretime = level.time + 1_sec;


### PR DESCRIPTION
## Summary
- add Freeze Tag helper routines for freezing and thawing players during rounds
- update round handling to award wins when teams are fully frozen or at the round time limit
- integrate Freeze Tag processing into client frame updates and respawn logic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df213e015c8328a96affbee26f13a2