### PR TITLE
Add detailed wiki pages for configuration, commands, and gameplay systems

### DIFF
--- a/docs/wiki/Command-Reference.md
+++ b/docs/wiki/Command-Reference.md
@@ -1,0 +1,63 @@
+# Command Reference
+
+Muff Mode expands the stock Quake II command set with a layered permission system so that everyday players, match officials, an
+d mappers can share the same server. Commands are registered with flag combinations in `client_cmds[]`, determining who can exe
+cute them, whether they function for spectators, and if cheats must be enabled. 【F:src/g_cmds.cpp†L3501-L3589】
+
+## Admin & Match Control Commands
+The `CF_ADMIN_ONLY` flag marks commands that require an authenticated admin session. They cover every phase of a match:
+
+- **Team management** – `balance`, `lockteam`, `unlockteam`, `setteam`, `shuffle`, `balance`, and `boot` let staff reshuffle or re
+move players to keep sides fair. 【F:src/g_cmds.cpp†L3505-L3580】
+- **Match state** – `startmatch`, `resetmatch`, `endmatch`, `readyall`, `unreadyall`, and `time-out`/`time-in` pairs give referees
+full control over countdowns and pauses. 【F:src/g_cmds.cpp†L3505-L3580】
+- **Map rotation** – `nextmap`, `setmap`, `map_restart`, `mymap`, and `spawn` handle rotation changes, queue curation, and entity
+spawning for exhibition events. 【F:src/g_cmds.cpp†L3509-L3584】
+- **Rules adjustments** – `gametype`, `ruleset`, and `forcevote` instantly apply new modes or rulesets without restarting, while `
+loadmotd` and `motd` update messaging. 【F:src/g_cmds.cpp†L3519-L3549】
+
+Players may request admin status with the `admin` command, after which `CF_ADMIN_ONLY` commands become available when the underl
+ying checks succeed. 【F:src/g_cmds.cpp†L3502-L3522】
+
+## General Player Controls
+Commands without admin requirements focus on quality-of-life and spectating support:
+
+- **Inventory & equipment** – `drop`, `invdrop`, `invnext`, `invprev`, `invuse`, `weapnext`, `weapprev`, and `use` mirror the in-g
+ame HUD controls, ensuring keyboard binds work even while navigating menus. 【F:src/g_cmds.cpp†L3511-L3589】
+- **Spectator tools** – `follow`, `followkiller`, `followleader`, `followpowerup`, `where`, `ghost`, and `team` let observers jump
+between points of interest and toggle chase cameras. 【F:src/g_cmds.cpp†L3515-L3590】
+- **Communication & feedback** – `announcer`, `fm` (frag messages), `timer`, `kb`, and `alertall` toggle HUD messaging while `hel
+p`, `score`, `stats`, and `players` report server state. 【F:src/g_cmds.cpp†L3503-L3577】
+- **Match readiness** – `ready`, `readyup`, `notready`, `forfeit`, and `vote` manage individual participation in duel queues, tea
+m warmups, and running ballots. 【F:src/g_cmds.cpp†L3520-L3589】
+
+## Cheat-Protected & Debug Commands
+The `CF_CHEAT_PROTECT` bit prevents potentially disruptive commands from running unless `g_cheats` is enabled. Typical examples
+include developer aids (`give`, `god`, `noclip`, `notarget`, `teleport`, `clear_ai_enemy`, `kill_ai`) and diagnostic tools (`list
+entities`, `listmonsters`, `target`, `setpoi`). 【F:src/g_cmds.cpp†L3508-L3576】
+
+## Voting System
+`callvote` (or its alias `cv`) exposes a server-configurable ballot system. When invoked, the command enumerates every vote type
+whose flag is not masked out by `g_vote_flags`, then validates the request against a suite of CVars:
+
+- Voting must be globally enabled via `g_allow_voting`, and servers can block mid-game calls with `g_allow_vote_midgame`.
+- Spectator voting requires `g_allow_spec_vote`; otherwise only active players may initiate ballots.
+- `g_vote_limit` caps how many proposals a single player can start per map.
+- The server defers new votes while `level.vote_time` or `level.vote_execute_time` is non-zero to avoid overlaps.
+
+These checks are all enforced inside `Cmd_CallVote_f`. 【F:src/g_cmds.cpp†L2758-L2816】
+
+Once accepted, the vote stores the initiating player as `level.vote_client`, queues a centerprint prompt, and opens the voting m
+enus for eligible participants. Casting a ballot via `vote` updates `level.vote_yes` or `level.vote_no`, with spectator access g
+uarded again. 【F:src/g_cmds.cpp†L2824-L2858】
+
+### Available Vote Commands
+`vote_cmds[]` defines the ballot catalog, pairing validator/payload callbacks with help text and flag bits that can be disabled i
+ndividually. 【F:src/g_cmds.cpp†L2632-L2645】 Supported votes include map changes, match restarts, gametype swaps, time/score lim
+it adjustments, shuffle/balance requests, unlagged toggles, cointoss decisions, random number rolls, and ruleset changes.
+
+## Tips
+- Use `forcevote` if an admin needs to override the outcome of a stalled ballot without interrupting match flow. 【F:src/g_cmds.c
+pp†L3519-L3550】
+- Encourage spectators to rely on `followleader` and `followpowerup` so automated camera tracking highlights key plays, reducing
+manual camera work during broadcasts. 【F:src/g_cmds.cpp†L3515-L3554】

--- a/docs/wiki/Gametypes-and-Mutators.md
+++ b/docs/wiki/Gametypes-and-Mutators.md
@@ -1,0 +1,48 @@
+# Gametypes & Mutators
+
+Muff Mode rebuilds the Quake II gametype framework so hosts can pivot between arena, objective, and PvE experiences with a sing
+le command. The `g_gametype` index instantly reconfigures the ruleset, stripping legacy toggles such as `duel` while keeping comp
+atibility flags (`ctf`, `teamplay`) synchronized. 【F:docs/progress.txt†L4-L22】
+
+## Gametype Catalog
+- **Free for All (1)** – Classic deathmatch tuned for Muff Mode’s HUD, scoreboard, and inventory QoL improvements. 【F:docs/progr
+ess.txt†L8-L22】
+- **Duel (2)** – Queue-based 1v1 battles with refined scoreboard and ready checks for smooth handoffs between challengers. 【F:do
+cs/progress.txt†L64-L70】
+- **Team Deathmatch (3)** – Teamplay inherits smarter balancing, ready indicators, and EyeCam support for spectators. 【F:docs/wi
+ki/Home.md†L8-L34】
+- **Capture the Flag (4)** – Works with drop permissions (`g_drop_cmds`) so admins can govern flag handling alongside new vote/st
+art commands. 【F:docs/progress.txt†L27-L33】
+- **Clan Arena (5)** – Round-based elimination with full weapon loadouts, optional armor/health tuning, and no self-damage by def
+ault. 【F:docs/progress.txt†L24-L41】
+- **Freeze Tag (6)** – Team revival combat benefitting from round countdowns and arena loadout CVars. 【F:docs/progress.txt†L31-L
+40】
+- **CaptureStrike (7)** – Alternating attacker/defender rounds combining CTF objectives with clan-arena loadouts. 【F:docs/progre
+ss.txt†L24-L33】
+- **Red Rover (8)** – Players swap sides on death until one team is empty; round tracking and score limits leverage the new match
+ flow CVars. 【F:docs/progress.txt†L24-L36】
+- **Last Man Standing (9)** – Survival-driven arena that relies on `roundlimit` and `g_round_countdown` for pacing. 【F:docs/progr
+ess.txt†L31-L37】
+- **Horde (10)** – Cooperative monster waves where players chase scoreboard supremacy across up to 16 rounds. 【F:docs/progress.t
+xt†L24-L29】
+- **ProBall (11)** – Fast-paced arena soccer with grappling focus; benefits from hook command bindings and vote support. 【F:docs/
+progress.txt†L16-L33】【F:docs/wiki/Home.md†L20-L34】
+
+## Round & Arena Controls
+Round-based modes share the same CVars: `roundlimit` (series length), `roundtimelimit` (per-round duration), `g_round_countdown`
+(pre-spawn countdown), and arena starting stacks (`g_arena_start_health`, `g_arena_start_armor`, `g_arena_dmg_armor`). These sett
+ings empower hosts to mimic Rocket Arena defaults or craft high-pressure sprint formats. 【F:docs/progress.txt†L31-L41】
+
+## Mutator Suite
+Mutators such as Vampiric Damage, Nade Fest, Weapons Frenzy, and Quad Hog can be mixed into any gametype, layering scoring twist
+s or pickup chaos on top of the base rules. Vampiric play respects `g_vampiric_exp_min`, ensuring leeching never drops health bel
+ow a chosen threshold. 【F:docs/wiki/Home.md†L20-L24】【F:docs/progress.txt†L40-L42】
+
+## Rulesets & Balance Context
+Three curated rulesets (Quake II Remastered, Muff Mode baseline, Quake III Arena) modulate weapon balance, armor behavior, and pi
+ckup cadence. For example, Muff Mode trims Plasma Beam range to 768 units in its take on Q2R balance, while the Q3A profile mimic
+s classic arena timing. 【F:docs/wiki/Home.md†L25-L27】【F:docs/progress.txt†L23-L52】
+
+Use `gametype` and `ruleset` commands—plus matching vote options—to script playlists that jump between competitive duel nights, c
+asual Horde co-op, and novelty mutator exhibitions without forcing clients to reconnect. 【F:src/g_cmds.cpp†L3519-L3568】【F:src/g_
+cmds.cpp†L2632-L2645】

--- a/docs/wiki/General-Features.md
+++ b/docs/wiki/General-Features.md
@@ -1,0 +1,34 @@
+# General Features
+
+Muff Mode layers dozens of quality-of-life upgrades on top of Quake II Remastered so servers feel turnkey at launch and remain f
+lexible for event play.
+
+## HUD, Scoreboard, and Control Menu
+- A custom HUD and scoreboard surface real-time team status, round results, and ready states, replacing the stock layout with to
+urnament-grade overlays. 【F:docs/wiki/Home.md†L4-L13】【F:docs/progress.txt†L64-L70】
+- The in-game control menu is synchronized with the status bar rendering pipeline, letting each client navigate match settings w
+ithout text command knowledge. 【F:docs/wiki/Home.md†L36-L41】
+
+## Administration & Player Quality-of-Life
+- Bundled configs, updated game logic, and bot assets provide a turnkey deployment path for hosts while exposing expanded admin t
+ools for match control. 【F:docs/wiki/Home.md†L6-L34】
+- Players gain enhanced toggles for announcers, frag messages, timers, grappling hooks, and duel-specific actions, keeping casual
+ users and competitors on equal footing. 【F:docs/wiki/Home.md†L31-L34】
+
+## Spectator & Broadcast Enhancements
+- EyeCam-style spectating, automated follow modes, and smart camera helpers give observers fine-grained control over match covera
+ge, ideal for streamed events. 【F:docs/wiki/Home.md†L8-L9】
+- Ready-state indicators and eliminated markers on team scoreboards let casters track momentum in round-based modes without spec
+tator guesswork. 【F:docs/progress.txt†L64-L70】
+
+## Level Design Tooling
+- Entity override controls, additional target/trigger helpers, and new item classes (personal teleporter, small/large ammo) expan
+d what map designers can script without custom DLL builds. 【F:docs/wiki/Home.md†L28-L29】【F:docs/progress.txt†L70-L104】
+- Designers can suspend pickups, gate events behind death counts or monster presence, and fire projectile shooters for grenades,
+ rockets, BFG, and more, enabling Quake III–style encounter logic inside Quake II maps. 【F:docs/progress.txt†L88-L131】
+
+## Content Packaging
+- The mod ships with “Muff Maps,” curated recreations of classic arenas such as Almost Lost and Longest Yard, ensuring consistent
+ rotation baselines for leagues. 【F:docs/wiki/Home.md†L8-L9】
+- Message-of-the-day management and entity override directories can be customized per event, supporting branded presentations wi
+thout rebuilding the DLL. 【F:docs/progress.txt†L40-L49】

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -5,6 +5,13 @@
 
 The distribution ships with updated game logic, curated server configuration, bot assets, and map entity overrides so hosts can deploy a turnkey experience out of the box.
 
+## Reference Pages
+- [Server Configuration](Server-Configuration.md)
+- [Command Reference](Command-Reference.md)
+- [General Features](General-Features.md)
+- [Gametypes & Mutators](Gametypes-and-Mutators.md)
+- [Match Features & Balance](Match-Features-and-Balance.md)
+
 Headline features include a purpose-built HUD/scoreboard, an in-game control menu, expanded admin tooling, deeper match-flow logic, smarter teamplay helpers, entity override controls, EyeCam spectating, and bundled “Muff Maps” recreations of classic arenas (Almost Lost, Arena of Death, Hidden Fortress, Longest Yard, Proving Grounds, Vertical Vengeance).
 
 ## Installation & Setup

--- a/docs/wiki/Match-Features-and-Balance.md
+++ b/docs/wiki/Match-Features-and-Balance.md
@@ -1,0 +1,37 @@
+# Match Features & Balance
+
+Beyond new gametypes, Muff Mode hardens match flow and rebalances combat to better suit competitive play.
+
+## Match Lifecycle Improvements
+- Instant gametype switching ensures playlists can jump between FFA, team, and arena modes without rebooting the lobby. 【F:docs/
+progress.txt†L4-L22】【F:docs/progress.txt†L64-L70】
+- Ready status indicators on every scoreboard reduce false starts and highlight eliminated players in round-based modes. 【F:docs
+/progress.txt†L64-L70】
+- Warmup quality-of-life additions—intermission pre-delays, smoother respawns, duel forfeits, and countdown CVars—keep matches f
+air while giving admins precise timing control. 【F:docs/wiki/Home.md†L20-L34】【F:docs/progress.txt†L31-L38】
+- Message-of-the-day management now pulls from `motd.txt`, with the `loadmotd` command refreshing broadcasts mid-session. 【F:doc
+s/progress.txt†L74-L78】【F:src/g_cmds.cpp†L3543-L3549】
+
+## Voting & Arbitration
+- Players can democratically adjust maps, time/score limits, rulesets, or request shuffles via the expanded vote catalog, while a
+dmins retain `forcevote` to resolve stalled ballots. 【F:src/g_cmds.cpp†L2632-L2645】【F:src/g_cmds.cpp†L3519-L3568】
+- Spectator participation and mid-game votes are governed by CVars, helping tournament organizers lock down competitive environm
+ents. 【F:src/g_cmds.cpp†L2758-L2816】
+
+## Balance Highlights
+- Plasma Beam range is capped at 768 units in the Quake II Remastered ruleset, tightening long-range pressure. 【F:docs/progress.
+txt†L52-L54】
+- Armor and weapon pickup behaviors shift with the active ruleset—Muff Mode adjusts ammo counts and protection values, while the
+ Quake III Arena profile mirrors that series’ timing. 【F:docs/wiki/Home.md†L25-L27】【F:docs/progress.txt†L23-L52】
+- Item drops are more permissive: blasters, grapples, and current weapons can now be dropped, supporting team economy plays. 【F:
+docs/progress.txt†L69-L73】
+- Smart weapon auto-switching prioritizes higher-tier weapons (SSG over SG, CG over MG) and avoids forced chainfist swaps, keepin
+g player intent intact. 【F:docs/progress.txt†L69-L73】
+
+## Arena Loadout Tuning
+Round-based modes use configurable starting stacks and optional self-damage armor rules, enabling hosts to recreate Rocket Arena,
+Quake III duel, or experimental high-health formats by simply editing CVars. 【F:docs/progress.txt†L31-L41】
+
+## Cooperative & PvE Support
+Horde waves scale up to 16 rounds, leveraging the same scoreboard infrastructure and drop rules so PvE nights feel consistent wit
+h competitive events. 【F:docs/progress.txt†L24-L36】【F:docs/progress.txt†L64-L73】

--- a/docs/wiki/Server-Configuration.md
+++ b/docs/wiki/Server-Configuration.md
@@ -1,0 +1,48 @@
+# Server Configuration
+
+Muff Mode exposes an extended suite of server CVars so hosts can tune everything from match pacing to arena loadouts without re
+compiling the DLL. The following tables summarize the most important variables, their defaults, and when to adjust them.
+
+## Core Administration CVars
+| CVar | Default | Description |
+| --- | --- | --- |
+| `g_ruleset` | `2` | Selects the active gameplay ruleset: Quake II Remastered (1), Muff Mode baseline (2), or Quake III Arena style (3); switching rulesets immediately reapplies armor, weapon, and pickup behaviors appropriate for that profile. 【F:docs/progress.txt†L23-L34】
+| `g_gametype` | `1` | Chooses the gametype by index, enabling instant transitions between deathmatch, arena, objective, and Horde variants without restarting the server process. 【F:docs/progress.txt†L8-L22】
+| `g_owner_auto_join` | `1` | Controls whether a lobby owner automatically joins the match on creation; disable when staging broadcast lobbies or ref-only sessions. 【F:docs/progress.txt†L41-L44】
+| `g_motd_filename` | `motd.txt` | Points to the message-of-the-day file; clearing the value reverts to the default banner loaded from baseq2. 【F:docs/progress.txt†L45-L49】
+
+## Match Flow & Round Control
+| CVar | Default | Description |
+| --- | --- | --- |
+| `roundlimit` | `8` | Sets the number of round wins required to capture a series in round-based gametypes such as Clan Arena, CaptureStrike, and Red Rover. 【F:docs/progress.txt†L31-L35】
+| `roundtimelimit` | `2` | Defines the per-round time limit (minutes) before a stalemate resolution kicks in. 【F:docs/progress.txt†L35-L36】
+| `g_round_countdown` | `10` | Adjusts the pre-round countdown seconds used to synchronize spawns and spectator camera cues. 【F:docs/progress.txt†L36-L37】
+| `g_owner_auto_join` | `1` | Prevents or enforces automatic lobby owner participation when matches roll forward, useful for tournament observers. 【F:docs/progress.txt†L41-L44】
+
+## Arena Loadout Tweaks
+| CVar | Default | Description |
+| --- | --- | --- |
+| `g_arena_start_health` | `200` | Defines the starting health pool in arena-derived gametypes, enabling Quake III–style 200/200 loadouts or leaner duel setups. 【F:docs/progress.txt†L37-L40】
+| `g_arena_start_armor` | `200` | Controls initial armor value (1–999) and implicitly the tier of armor granted to each player. 【F:docs/progress.txt†L37-L40】
+| `g_arena_dmg_armor` | `0` | Toggles whether self-damage subtracts armor in arena modes, letting servers mimic Rocket Arena (no self-damage) or traditional settings. 【F:docs/progress.txt†L37-L40】
+| `g_starting_health` | `100` | Sets spawn health outside arena contexts, applying to FFA, TDM, and objective matches alike. 【F:docs/progress.txt†L45-L48】
+| `g_starting_armor` | `0` | Mirrors `g_starting_health` for non-arena armor spawn values, allowing “full stack” warmups or barebones instagib loadouts. 【F:docs/progress.txt†L45-L48】
+
+## Powerup, Drop, and Economy Controls
+| CVar | Default | Description |
+| --- | --- | --- |
+| `g_drop_cmds` | `7` | Bitflag gate for what items can be voluntarily dropped: `&1` CTF flags, `&2` powerups, `&4` weapons and ammo. Combine flags (e.g., `3`) to enable subsets. 【F:docs/progress.txt†L27-L33】
+| `g_vampiric_exp_min` | `0` | Sets the minimum health a player can decay toward when Vampiric Damage mutator is active, preventing overheal collapse below a configured floor. 【F:docs/progress.txt†L40-L42】
+| `bot_name_prefix` | `"B|"` | Customizes bot name prefixes, useful for labeling AI slots or distinguishing skill tiers. 【F:docs/progress.txt†L24-L28】
+| `g_allow_kill` | `1` | Enables or disables the classic `kill` self-termination command, often banned in competitive duel rotations. 【F:docs/progress.txt†L26-L27】
+
+## File & Content Overrides
+| CVar | Default | Description |
+| --- | --- | --- |
+| `g_entity_override_dir` | `maps` | Repoints the entity override directory inside baseq2, allowing per-map logic tweaks without touching packaged BSPs. 【F:docs/progress.txt†L40-L41】
+
+## Tips for Hosts
+- Pair `g_gametype` with server-side vote restrictions to guarantee that late-joiners see the intended rotation instantly.
+- When running mixed-arena playlists, keep `roundlimit` conservative (6–8) to maintain brisk match turnover.
+- Disable `g_arena_dmg_armor` if you expect players to rely heavily on rocket-jumps; combined with high `g_arena_start_armor`, this mirrors Rocket Arena expectations.
+- Use unique `bot_name_prefix` values when orchestrating PvE Horde events so spectators can immediately identify AI allies.


### PR DESCRIPTION
## Summary
- add standalone server configuration guide covering core CVars and arena tuning options
- document admin, player, and cheat commands plus voting workflows in a dedicated reference page
- expand the wiki with general features, gametype and mutator overviews, and match balance highlights linked from the home page

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df267111c48328bc6d5df58ac2f312