### PR TITLE
Rename g_local header and tidy match helpers

### DIFF
--- a/src/bg_local.h
+++ b/src/bg_local.h
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-// g_local.h -- local definitions for game module
+// bg_local.h -- shared game definitions for client and server modules
 #pragma once
 
 #include "q_std.h"

--- a/src/bots/bot_debug.cpp
+++ b/src/bots/bot_debug.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "bot_utils.h"
 #include "bot_debug.h"
 

--- a/src/bots/bot_exports.cpp
+++ b/src/bots/bot_exports.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "bot_exports.h"
 
 /*

--- a/src/bots/bot_think.cpp
+++ b/src/bots/bot_think.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "bot_think.h"
 
 /*

--- a/src/bots/bot_utils.cpp
+++ b/src/bots/bot_utils.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "../monsters/m_player.h"
 #include "bot_utils.h"
 

--- a/src/g_ai.cpp
+++ b/src/g_ai.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_ai.c
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 bool FindTarget(gentity_t *self);
 bool ai_checkattack(gentity_t *self, float dist);

--- a/src/g_ai_new.cpp
+++ b/src/g_ai_new.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 //===============================
 // BLOCKED Logic

--- a/src/g_chase.cpp
+++ b/src/g_chase.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 
 void FreeFollower(gentity_t *ent) {
 	if (!ent)

--- a/src/g_cmds.cpp
+++ b/src/g_cmds.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 #include "monsters/m_player.h"
 enum cmd_flags_t : uint32_t {
 	CF_NONE				= 0,

--- a/src/g_combat.cpp
+++ b/src/g_combat.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_combat.c
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 #include <algorithm>
 #include <array>

--- a/src/g_ctf.cpp
+++ b/src/g_ctf.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 
 constexpr int32_t CTF_CAPTURE_BONUS = 15;	  // what you get for capture
 constexpr int32_t CTF_TEAM_BONUS = 10;   // what your team gets for capture

--- a/src/g_func.cpp
+++ b/src/g_func.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 
 /*
 =========================================================

--- a/src/g_items.cpp
+++ b/src/g_items.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 #include "bots/bot_includes.h"
 #include "monsters/m_player.h"	//doppelganger
 #include <array>

--- a/src/g_local.hpp
+++ b/src/g_local.hpp
@@ -1,11 +1,14 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-// g_local.h -- local definitions for game module
+// g_local.hpp -- local definitions for game module
 #pragma once
 
 #include "bg_local.h"
 #include "g_cvars.hpp"
+
+struct level_locals_t;
+extern level_locals_t level;
 
 // the "gameversion" client command will print this plus compile date
 constexpr const char *GAMEVERSION = "baseq2";
@@ -324,48 +327,48 @@ typedef enum {
 // Keeping the helpers here avoids scattering fragile enum comparisons
 // across the codebase and makes the intent of the checks clearer.
 //
-constexpr bool Match_IsNone(matchst_t state) {
-	return state == matchst_t::MATCH_NONE;
+[[nodiscard]] constexpr bool Match_IsNone(matchst_t state) {
+        return state == matchst_t::MATCH_NONE;
 }
 
-constexpr bool Match_IsDelayedWarmup(matchst_t state) {
-	return state == matchst_t::MATCH_WARMUP_DELAYED;
+[[nodiscard]] constexpr bool Match_IsDelayedWarmup(matchst_t state) {
+        return state == matchst_t::MATCH_WARMUP_DELAYED;
 }
 
-constexpr bool Match_IsDefaultWarmup(matchst_t state) {
-	return state == matchst_t::MATCH_WARMUP_DEFAULT;
+[[nodiscard]] constexpr bool Match_IsDefaultWarmup(matchst_t state) {
+        return state == matchst_t::MATCH_WARMUP_DEFAULT;
 }
 
-constexpr bool Match_IsReadyUp(matchst_t state) {
-	return state == matchst_t::MATCH_WARMUP_READYUP;
+[[nodiscard]] constexpr bool Match_IsReadyUp(matchst_t state) {
+        return state == matchst_t::MATCH_WARMUP_READYUP;
 }
 
-constexpr bool Match_IsActiveWarmup(matchst_t state) {
-	return Match_IsDefaultWarmup(state) || Match_IsReadyUp(state);
+[[nodiscard]] constexpr bool Match_IsActiveWarmup(matchst_t state) {
+        return Match_IsDefaultWarmup(state) || Match_IsReadyUp(state);
 }
 
-constexpr bool Match_IsCountdown(matchst_t state) {
-	return state == matchst_t::MATCH_COUNTDOWN;
+[[nodiscard]] constexpr bool Match_IsCountdown(matchst_t state) {
+        return state == matchst_t::MATCH_COUNTDOWN;
 }
 
-constexpr bool Match_IsPreGame(matchst_t state) {
-	return state > matchst_t::MATCH_NONE && state < matchst_t::MATCH_IN_PROGRESS;
+[[nodiscard]] constexpr bool Match_IsPreGame(matchst_t state) {
+        return state > matchst_t::MATCH_NONE && state < matchst_t::MATCH_IN_PROGRESS;
 }
 
-constexpr bool Match_IsPreCountdown(matchst_t state) {
-	return state < matchst_t::MATCH_COUNTDOWN;
+[[nodiscard]] constexpr bool Match_IsPreCountdown(matchst_t state) {
+        return state < matchst_t::MATCH_COUNTDOWN;
 }
 
-constexpr bool Match_IsOngoing(matchst_t state) {
-	return state == matchst_t::MATCH_IN_PROGRESS;
+[[nodiscard]] constexpr bool Match_IsOngoing(matchst_t state) {
+        return state == matchst_t::MATCH_IN_PROGRESS;
 }
 
-constexpr bool Match_HasStarted(matchst_t state) {
-	return state >= matchst_t::MATCH_IN_PROGRESS;
+[[nodiscard]] constexpr bool Match_HasStarted(matchst_t state) {
+        return state >= matchst_t::MATCH_IN_PROGRESS;
 }
 
-constexpr bool Match_IsPostGame(matchst_t state) {
-	return state == matchst_t::MATCH_ENDED;
+[[nodiscard]] constexpr bool Match_IsPostGame(matchst_t state) {
+        return state == matchst_t::MATCH_ENDED;
 }
 
 inline void Match_SetState(matchst_t new_state, gtime_t timer = 0_sec) {
@@ -2294,7 +2297,6 @@ using save_die_t = save_data_t<void(*)(gentity_t *self, gentity_t *inflictor, ge
 constexpr gtime_t DUCK_INTERVAL = 5000_ms;
 
 extern game_locals_t  game;
-extern level_locals_t level;
 extern game_export_t  globals;
 extern spawn_temp_t	  st;
 

--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "g_local.h"
+#include "g_local.hpp"
 #include "bots/bot_includes.h"
 #include "monsters/m_player.h"	// match starts
 

--- a/src/g_menu.cpp
+++ b/src/g_menu.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 #include "monsters/m_player.h"
 
 #include <assert.h>

--- a/src/g_misc.cpp
+++ b/src/g_misc.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_misc.c
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 #include <algorithm>
 #include <cstdlib>

--- a/src/g_monster.cpp
+++ b/src/g_monster.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 #include "bots/bot_includes.h"
 
 //

--- a/src/g_monster_spawn.cpp
+++ b/src/g_monster_spawn.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 //
 // Monster spawning code

--- a/src/g_phys.cpp
+++ b/src/g_phys.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_phys.c
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 /*
 

--- a/src/g_save.cpp
+++ b/src/g_save.cpp
@@ -3,7 +3,7 @@
 
 #include <sstream>
 
-#include "g_local.h"
+#include "g_local.hpp"
 #include <float.h>
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/src/g_spawn.cpp
+++ b/src/g_spawn.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 struct spawn_t {
 	const char *name;

--- a/src/g_svcmds.cpp
+++ b/src/g_svcmds.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 static void Svcmd_Test_f() {
 	gi.LocClient_Print(nullptr, PRINT_HIGH, "Svcmd_Test_f()\n");

--- a/src/g_target.cpp
+++ b/src/g_target.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 
 /*QUAKED target_temp_entity (1 0 0) (-8 -8 -8) (8 8 8) x x x x x x x x NOT_EASY NOT_MEDIUM NOT_HARD NOT_DM NOT_COOP
 Fire an origin based temp entity event to the clients.

--- a/src/g_trigger.cpp
+++ b/src/g_trigger.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 
 constexpr spawnflags_t SPAWNFLAG_TRIGGER_MONSTER = 0x01_spawnflag;
 constexpr spawnflags_t SPAWNFLAG_TRIGGER_NOT_PLAYER = 0x02_spawnflag;

--- a/src/g_turret.cpp
+++ b/src/g_turret.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_turret.c
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 constexpr spawnflags_t SPAWNFLAG_TURRET_BREACH_FIRE = 65536_spawnflag;
 

--- a/src/g_utils.cpp
+++ b/src/g_utils.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_utils.c -- misc utility functions for game module
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 #include <algorithm>
 #include <array>

--- a/src/g_weapon.cpp
+++ b/src/g_weapon.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 
 /*
 =================

--- a/src/game.vcxproj
+++ b/src/game.vcxproj
@@ -112,7 +112,7 @@
     <ClInclude Include="bots\bot_utils.h" />
     <ClInclude Include="cg_local.h" />
     <ClInclude Include="game.h" />
-    <ClInclude Include="g_local.h" />
+    <ClInclude Include="g_local.hpp" />
     <ClInclude Include="g_statusbar.h" />
     <ClInclude Include="monsters\m_actor.h" />
     <ClInclude Include="monsters\m_arachnid.h" />

--- a/src/game.vcxproj.filters
+++ b/src/game.vcxproj.filters
@@ -3,7 +3,7 @@
   <ItemGroup>
     <ClInclude Include="bg_local.h" />
     <ClInclude Include="cg_local.h" />
-    <ClInclude Include="g_local.h" />
+    <ClInclude Include="g_local.hpp" />
     <ClInclude Include="g_statusbar.h" />
     <ClInclude Include="game.h" />
     <ClInclude Include="q_std.h" />

--- a/src/monsters/m_actor.cpp
+++ b/src/monsters/m_actor.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_actor.c
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_actor.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_arachnid.cpp
+++ b/src/monsters/m_arachnid.cpp
@@ -8,7 +8,7 @@ TANK
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_arachnid.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_berserk.cpp
+++ b/src/monsters/m_berserk.cpp
@@ -8,7 +8,7 @@ BERSERK
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_berserk.h"
 
 constexpr spawnflags_t SPAWNFLAG_BERSERK_NOJUMPING = 8_spawnflag;

--- a/src/monsters/m_boss2.cpp
+++ b/src/monsters/m_boss2.cpp
@@ -8,7 +8,7 @@ boss2
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_boss2.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_boss3.cpp
+++ b/src/monsters/m_boss3.cpp
@@ -8,7 +8,7 @@ boss3
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_boss32.h"
 
 USE(Use_Boss3) (gentity_t *self, gentity_t *other, gentity_t *activator) -> void {

--- a/src/monsters/m_boss31.cpp
+++ b/src/monsters/m_boss31.cpp
@@ -8,7 +8,7 @@ jorg
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_boss31.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_boss32.cpp
+++ b/src/monsters/m_boss32.cpp
@@ -8,7 +8,7 @@ Makron -- Final Boss
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_boss32.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_brain.cpp
+++ b/src/monsters/m_brain.cpp
@@ -8,7 +8,7 @@ brain
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_brain.h"
 
 static cached_soundindex sound_chest_open;

--- a/src/monsters/m_carrier.cpp
+++ b/src/monsters/m_carrier.cpp
@@ -12,7 +12,7 @@ carrier
 // self->timestamp used for frame calculations in grenade & spawn code
 // self->monsterinfo.fire_wait used to prevent rapid refire of rocket launcher
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_carrier.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_chick.cpp
+++ b/src/monsters/m_chick.cpp
@@ -8,7 +8,7 @@ chick
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_chick.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_fixbot.cpp
+++ b/src/monsters/m_fixbot.cpp
@@ -4,7 +4,7 @@
 	fixbot.c
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_fixbot.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_flipper.cpp
+++ b/src/monsters/m_flipper.cpp
@@ -8,7 +8,7 @@ FLIPPER
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_flipper.h"
 
 static cached_soundindex sound_chomp;

--- a/src/monsters/m_float.cpp
+++ b/src/monsters/m_float.cpp
@@ -8,7 +8,7 @@ floater
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_float.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_flyer.cpp
+++ b/src/monsters/m_flyer.cpp
@@ -8,7 +8,7 @@ flyer
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_flyer.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_gekk.cpp
+++ b/src/monsters/m_gekk.cpp
@@ -5,7 +5,7 @@
 	gekk.c
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_gekk.h"
 
 constexpr spawnflags_t SPAWNFLAG_GEKK_CHANT = 8_spawnflag;

--- a/src/monsters/m_gladiator.cpp
+++ b/src/monsters/m_gladiator.cpp
@@ -8,7 +8,7 @@ GLADIATOR
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_gladiator.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_guardian.cpp
+++ b/src/monsters/m_guardian.cpp
@@ -8,7 +8,7 @@ GUARDIAN
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_guardian.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_guncmdr.cpp
+++ b/src/monsters/m_guncmdr.cpp
@@ -8,7 +8,7 @@ GUNNER
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_gunner.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_gunner.cpp
+++ b/src/monsters/m_gunner.cpp
@@ -8,7 +8,7 @@ GUNNER
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_gunner.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_hover.cpp
+++ b/src/monsters/m_hover.cpp
@@ -8,7 +8,7 @@ hover
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_hover.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_infantry.cpp
+++ b/src/monsters/m_infantry.cpp
@@ -8,7 +8,7 @@ INFANTRY
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_infantry.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_insane.cpp
+++ b/src/monsters/m_insane.cpp
@@ -8,7 +8,7 @@ insane
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_insane.h"
 
 constexpr spawnflags_t SPAWNFLAG_INSANE_CRAWL = 4_spawnflag;

--- a/src/monsters/m_medic.cpp
+++ b/src/monsters/m_medic.cpp
@@ -8,7 +8,7 @@ MEDIC
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_medic.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_move.cpp
+++ b/src/monsters/m_move.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // m_move.c -- monster movement
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 
 // this is used for communications out of g_movestep to say what entity
 // is blocking us

--- a/src/monsters/m_mutant.cpp
+++ b/src/monsters/m_mutant.cpp
@@ -8,7 +8,7 @@ mutant
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_mutant.h"
 
 constexpr spawnflags_t SPAWNFLAG_MUTANT_NOJUMPING = 8_spawnflag;

--- a/src/monsters/m_parasite.cpp
+++ b/src/monsters/m_parasite.cpp
@@ -8,7 +8,7 @@ parasite
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_parasite.h"
 
 constexpr float g_athena_parasite_miss_chance = 0.1f;

--- a/src/monsters/m_shambler.cpp
+++ b/src/monsters/m_shambler.cpp
@@ -8,7 +8,7 @@ SHAMBLER
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_shambler.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_soldier.cpp
+++ b/src/monsters/m_soldier.cpp
@@ -8,7 +8,7 @@ SOLDIER
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_soldier.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_stalker.cpp
+++ b/src/monsters/m_stalker.cpp
@@ -8,7 +8,7 @@ stalker
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_stalker.h"
 #include <float.h>
 

--- a/src/monsters/m_supertank.cpp
+++ b/src/monsters/m_supertank.cpp
@@ -8,7 +8,7 @@ SUPERTANK
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_supertank.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_tank.cpp
+++ b/src/monsters/m_tank.cpp
@@ -8,7 +8,7 @@ TANK
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_tank.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_turret.cpp
+++ b/src/monsters/m_turret.cpp
@@ -8,7 +8,7 @@ TURRET
 ==============================================================================
 */
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_turret.h"
 
 constexpr spawnflags_t SPAWNFLAG_TURRET_BLASTER = 0x0008_spawnflag;

--- a/src/monsters/m_widow.cpp
+++ b/src/monsters/m_widow.cpp
@@ -11,7 +11,7 @@ black widow
 // self->timestamp used to prevent rapid fire of railgun
 // self->plat2flags used for fire count (flashes)
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_widow.h"
 #include "m_flash.h"
 

--- a/src/monsters/m_widow2.cpp
+++ b/src/monsters/m_widow2.cpp
@@ -10,7 +10,7 @@ black widow, part 2
 
 // timestamp used to prevent rapid fire of melee attack
 
-#include "../g_local.h"
+#include "../g_local.hpp"
 #include "m_widow2.h"
 #include "m_flash.h"
 

--- a/src/p_client.cpp
+++ b/src/p_client.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 #include "monsters/m_player.h"
 #include "bots/bot_includes.h"
 

--- a/src/p_hud.cpp
+++ b/src/p_hud.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 #include "g_statusbar.h"
 
 #include <algorithm>

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 
 /*
 ============

--- a/src/p_trail.cpp
+++ b/src/p_trail.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
-#include "g_local.h"
+#include "g_local.hpp"
 
 #include <cstddef>
 #include <limits>

--- a/src/p_view.cpp
+++ b/src/p_view.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include "g_local.h"
+#include "g_local.hpp"
 #include "monsters/m_player.h"
 #include "bots/bot_includes.h"
 

--- a/src/p_weapon.cpp
+++ b/src/p_weapon.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_weapon.c
 
-#include "g_local.h"
+#include "g_local.hpp"
 #include "monsters/m_player.h"
 
 #include <array>

--- a/src/q_std.cpp
+++ b/src/q_std.cpp
@@ -3,7 +3,7 @@
 
 // standard library stuff for game DLL
 
-#include "g_local.h"
+#include "g_local.hpp"
 
 //====================================================================================
 


### PR DESCRIPTION
## Summary
- rename the gameplay header to g_local.hpp, add the forward declaration for level_locals_t, and annotate the match helper utilities
- update every include along with the Visual Studio project files to point at the new header name
- fix the shared bg_local.h banner comment while touching the file during the rename

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df97a3259c83289196466c10cfba1b