### PR TITLE
Fix MSVC compilation issues for menu stats and gravity lotto

### DIFF
--- a/src/g_menu.cpp
+++ b/src/g_menu.cpp
@@ -330,8 +330,11 @@ static void G_Menu_PMStats_Update(gentity_t *ent) {
                 ++i;
         };
 
-        auto add_fmt = [&](auto &&... args) {
-                add_line(G_Fmt(std::forward<decltype(args)>(args)...));
+        auto add_fmt = [&](const auto &format_str, auto &&... args) {
+                if (i >= max_entries)
+                        return;
+                G_FmtTo_(entries[i].text, format_str, std::forward<decltype(args)>(args)...);
+                ++i;
         };
 
         auto add_blank = [&]() {


### PR DESCRIPTION
## Summary
- rework the player-match stats menu helpers to avoid MSVC preprocessor issues while keeping formatting intact
- update match state timer handling, gravity lotto messaging, and pendulum updates to rely only on supported data structures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df9d93c73c8328872cbeff4d7735c4