### PR TITLE
Ensure exported API symbols use C linkage

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -104,7 +104,7 @@ constexpr bit_t<n> bit_v = 1ull << n;
 #elif defined(KEX_Q2GAME_IMPORTS)
 #define Q2GAME_API extern "C" __declspec( dllimport )
 #else
-#define Q2GAME_API
+#define Q2GAME_API extern "C"
 #endif
 
 // game.h -- game dll information visible to server


### PR DESCRIPTION
## Summary
- make the fallback Q2GAME_API macro include extern "C" so GetGameAPI and GetCGameAPI are exported with C linkage even when the build does not define KEX_Q2GAME_EXPORTS

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dfa149e89883288f07c6cb9ddd099b