### PR TITLE
Restore manual cvar initialization for engine compatibility

### DIFF
--- a/src/g_cvars.hpp
+++ b/src/g_cvars.hpp
@@ -2,7 +2,6 @@
 
 #include "q_std.h"
 
-#include <cstddef>
 #include <cstdint>
 
 #include "game.h"
@@ -12,23 +11,13 @@ enum class game_cvar_stage : uint8_t {
         INIT,
 };
 
-using cvar_default_fn = const char *(*)();
-
-struct game_cvar_descriptor {
-        cvar_t **storage;
-        const char *name;
-        cvar_default_fn default_fn;
-        cvar_flags_t flags;
-        game_cvar_stage stage;
-};
-
 #define CVAR_LITERAL(value) []() -> const char * { return value; }
 #define CVAR_VALUE(expr) []() -> const char * { return (expr); }
 
 #define STRINGIFY_IMPL(value) #value
 #define STRINGIFY(value) STRINGIFY_IMPL(value)
 
-inline const char *DefaultCheatsValue()
+[[maybe_unused]] inline const char *DefaultCheatsValue()
 {
 #if defined(_DEBUG)
         return "1";
@@ -231,24 +220,6 @@ inline const char *DefaultCheatsValue()
 #define DECLARE_GAME_CVAR(stage, identifier, name, default_fn, flags) inline cvar_t *identifier = nullptr;
 GAME_CVAR_ENTRIES(DECLARE_GAME_CVAR)
 #undef DECLARE_GAME_CVAR
-
-inline const game_cvar_descriptor g_game_cvar_descriptors[] = {
-#define DEFINE_GAME_CVAR(stage, identifier, name, default_fn, flags) { &identifier, name, default_fn, flags, stage },
-        GAME_CVAR_ENTRIES(DEFINE_GAME_CVAR)
-#undef DEFINE_GAME_CVAR
-};
-
-inline constexpr size_t g_game_cvar_descriptors_count = sizeof(g_game_cvar_descriptors) / sizeof(g_game_cvar_descriptors[0]);
-
-template<typename Fn>
-inline void ForEachGameCvar(game_cvar_stage stage, Fn &&fn)
-{
-        for (const auto &descriptor : g_game_cvar_descriptors) {
-                if (descriptor.stage == stage) {
-                        fn(descriptor);
-                }
-        }
-}
 
 #undef GAME_CVAR_ENTRIES
 #undef CVAR_LITERAL

--- a/src/game.h
+++ b/src/game.h
@@ -104,7 +104,7 @@ constexpr bit_t<n> bit_v = 1ull << n;
 #elif defined(KEX_Q2GAME_IMPORTS)
 #define Q2GAME_API extern "C" __declspec( dllimport )
 #else
-#define Q2GAME_API
+#define Q2GAME_API extern "C"
 #endif
 
 // game.h -- game dll information visible to server
@@ -1244,15 +1244,11 @@ enum {
 struct configstring_remap_t {
 	// start position in the configstring list
 	// to write into
-	size_t	start;
+	size_t  start;
 	// max length to write into; [start+length-1] should always
 	// be set to '\0'
-	size_t	length;
+	size_t  length;
 };
-
-constexpr size_t cs_remap_offset(int32_t id, int32_t newer, int32_t older, size_t stride = CS_MAX_STRING_LENGTH) {
-	return static_cast<size_t>(static_cast<int64_t>(id) + static_cast<int64_t>(newer) - static_cast<int64_t>(older)) * stride;
-}
 
 constexpr configstring_remap_t CS_REMAP(int32_t id) {
 	// direct mapping
@@ -1264,23 +1260,23 @@ constexpr configstring_remap_t CS_REMAP(int32_t id) {
 		return { (CS_STATUSBAR * CS_MAX_STRING_LENGTH) + ((id - CS_STATUSBAR_OLD) * CS_MAX_STRING_LENGTH_OLD), (CS_AIRACCEL - CS_STATUSBAR) * CS_MAX_STRING_LENGTH };
 	// offset
 	else if (id < CS_MODELS_OLD)
-		return { cs_remap_offset(id, CS_AIRACCEL, CS_AIRACCEL_OLD), CS_MAX_STRING_LENGTH };
+		return { (id + (CS_AIRACCEL - CS_AIRACCEL_OLD)) * CS_MAX_STRING_LENGTH, CS_MAX_STRING_LENGTH };
 	else if (id < CS_SOUNDS_OLD)
-		return { cs_remap_offset(id, CS_MODELS, CS_MODELS_OLD), CS_MAX_STRING_LENGTH };
+		return { (id + (CS_MODELS - CS_MODELS_OLD)) * CS_MAX_STRING_LENGTH, CS_MAX_STRING_LENGTH };
 	else if (id < CS_IMAGES_OLD)
-		return { cs_remap_offset(id, CS_SOUNDS, CS_SOUNDS_OLD), CS_MAX_STRING_LENGTH };
+		return { (id + (CS_SOUNDS - CS_SOUNDS_OLD)) * CS_MAX_STRING_LENGTH, CS_MAX_STRING_LENGTH };
 	else if (id < CS_LIGHTS_OLD)
-		return { cs_remap_offset(id, CS_IMAGES, CS_IMAGES_OLD), CS_MAX_STRING_LENGTH };
+		return { (id + (CS_IMAGES - CS_IMAGES_OLD)) * CS_MAX_STRING_LENGTH, CS_MAX_STRING_LENGTH };
 	else if (id < CS_ITEMS_OLD)
-		return { cs_remap_offset(id, CS_LIGHTS, CS_LIGHTS_OLD), CS_MAX_STRING_LENGTH };
+		return { (id + (CS_LIGHTS - CS_LIGHTS_OLD)) * CS_MAX_STRING_LENGTH, CS_MAX_STRING_LENGTH };
 	else if (id < CS_PLAYERSKINS_OLD)
-		return { cs_remap_offset(id, CS_ITEMS, CS_ITEMS_OLD), CS_MAX_STRING_LENGTH };
+		return { (id + (CS_ITEMS - CS_ITEMS_OLD)) * CS_MAX_STRING_LENGTH, CS_MAX_STRING_LENGTH };
 	else if (id < CS_GENERAL_OLD)
-		return { cs_remap_offset(id, CS_PLAYERSKINS, CS_PLAYERSKINS_OLD), CS_MAX_STRING_LENGTH };
+		return { (id + (CS_PLAYERSKINS - CS_PLAYERSKINS_OLD)) * CS_MAX_STRING_LENGTH, CS_MAX_STRING_LENGTH };
 
 	// general also needs some special handling because it's both
 	// offset *and* allowed to overflow
-	return { cs_remap_offset(id, CS_GENERAL, CS_GENERAL_OLD, CS_MAX_STRING_LENGTH_OLD), (MAX_CONFIGSTRINGS - CS_GENERAL) * CS_MAX_STRING_LENGTH };
+	return { (id + (CS_GENERAL - CS_GENERAL_OLD)) * CS_MAX_STRING_LENGTH_OLD, (MAX_CONFIGSTRINGS - CS_GENERAL) * CS_MAX_STRING_LENGTH };
 }
 
 static_assert(CS_REMAP(CS_MODELS_OLD).start == (CS_MODELS * 96), "check CS_REMAP");


### PR DESCRIPTION
## Summary
- restore the legacy manual cvar registration in PreInitGame and InitGame so engine entry points match the older hook behavior
- drop the unused cvar descriptor helpers now that registration is handled explicitly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa149e89883288f07c6cb9ddd099b