### PR TITLE
Handle CalculateRanks with no connected clients

### DIFF
--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -2298,9 +2298,17 @@ void CalculateRanks() {
 		}
 	}
 
-	int lead_score = game.clients[level.sorted_clients[0]].resp.score;
+        bool have_connected_clients = level.num_connected_clients > 0;
+        int lead_score = 0;
 
-	qsort(level.sorted_clients, level.num_connected_clients, sizeof(level.sorted_clients[0]), SortRanks);
+        if (have_connected_clients) {
+                lead_score = game.clients[level.sorted_clients[0]].resp.score;
+
+                qsort(level.sorted_clients, level.num_connected_clients, sizeof(level.sorted_clients[0]), SortRanks);
+        } else {
+                level.follow1 = -1;
+                level.follow2 = -1;
+        }
 
 	// set the rank value for all clients that are connected and not spectators
 	if (teams && notGT(GT_RR)) {
@@ -2344,7 +2352,7 @@ void CalculateRanks() {
 	
 	level.warmup_notice_time = level.time;
 
-	if (level.match_state == MATCH_IN_PROGRESS) {
+        if (level.match_state == MATCH_IN_PROGRESS && have_connected_clients) {
 		if (GTF(GTF_FRAGS)) {
 			//gi.Com_PrintFmt("new={} old={}\n", game.clients[level.sorted_clients[0]].resp.score, old_first_score);
 			if (fraglimit->integer > 3) {


### PR DESCRIPTION
## Summary
- guard CalculateRanks against empty client lists before sorting or reading rank data
- reset spectator follow targets and skip match-state logic when the server has no connected clients

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0eac8cd5c8328b6e9147e1e14590e