### PR TITLE
Improve changelevel error handling and diagnostics

### DIFF
--- a/src/g_local.hpp
+++ b/src/g_local.hpp
@@ -1595,6 +1595,7 @@ struct level_locals_t {
 										// kills during this delay
 
 	const char	*changemap;
+	char		changemap_context[256];
 	const char	*achievement;
 	bool		intermission_exit;
 	bool		intermission_eou;

--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -2633,6 +2633,16 @@ static void ClientEndServerFrames() {
 		ClientEndServerFrame(ec);
 }
 
+static const char *ChangeLevelDebugValue(const char *value) {
+	if (!value)
+		return "<null>";
+
+	if (!*value)
+		return "<empty>";
+
+	return value;
+}
+
 /*
 =================
 CreateTargetChangeLevel
@@ -2645,6 +2655,12 @@ gentity_t *CreateTargetChangeLevel(const char *map) {
 
 	ent = G_Spawn();
 	ent->classname = "target_changelevel";
+	if (!map || !*map) {
+		gi.Com_PrintFmt("WARNING: CreateTargetChangeLevel received {} map value; defaulting to current map \'{}\'\n",
+			map ? "an empty" : "a null", ChangeLevelDebugValue(level.mapname));
+		map = level.mapname;
+	}
+
 	Q_strlcpy(level.nextmap, map, sizeof(level.nextmap));
 	ent->map = level.nextmap;
 	return ent;
@@ -3101,7 +3117,42 @@ void BeginIntermission(gentity_t *targ) {
 	}
 
 	level.intermission_server_frame = gi.ServerFrame();
-	level.changemap = targ->map;
+	level.changemap_context[0] = '\0';
+
+	if (!targ) {
+		gi.Com_PrintFmt("WARNING: BeginIntermission invoked without a changelevel target; synthesizing fallback for \'{}\'\n",
+			ChangeLevelDebugValue(level.mapname));
+		targ = CreateTargetChangeLevel(level.mapname);
+	}
+
+	const bool has_changemap_value = targ && targ->map && targ->map[0];
+	if (targ && !has_changemap_value)
+		gi.Com_PrintFmt("WARNING: BeginIntermission target {} provided {} changemap value; defaulting to current map \'{}\'\n",
+			*targ, targ->map ? "an empty" : "a null", ChangeLevelDebugValue(level.mapname));
+
+	const char *resolved_changemap = has_changemap_value ? targ->map : (level.mapname[0] ? level.mapname : nullptr);
+	level.changemap = resolved_changemap;
+
+	if (targ) {
+		Q_strlcpy(level.changemap_context,
+			G_Fmt("target={} requested_map={} resolved_map={} nextmap_hint={} current_map={}",
+				*targ,
+				ChangeLevelDebugValue(targ->map),
+				ChangeLevelDebugValue(resolved_changemap),
+				ChangeLevelDebugValue(level.nextmap[0] ? level.nextmap : nullptr),
+				ChangeLevelDebugValue(level.mapname))
+				.data(),
+			sizeof(level.changemap_context));
+	} else {
+		Q_strlcpy(level.changemap_context,
+			G_Fmt("target=<null> requested_map=<null> resolved_map={} nextmap_hint={} current_map={}",
+				ChangeLevelDebugValue(resolved_changemap),
+				ChangeLevelDebugValue(level.nextmap[0] ? level.nextmap : nullptr),
+				ChangeLevelDebugValue(level.mapname))
+				.data(),
+			sizeof(level.changemap_context));
+	}
+
 	level.intermission_clear = targ->spawnflags.has(SPAWNFLAG_CHANGELEVEL_CLEAR_INVENTORY);
 	level.intermission_eou = false;
 	level.intermission_fade = targ->spawnflags.has(SPAWNFLAG_CHANGELEVEL_FADE_OUT);
@@ -3112,7 +3163,7 @@ void BeginIntermission(gentity_t *targ) {
 	// [Paril-KEX] update game level entry
 	G_UpdateLevelEntry();
 
-	if (strstr(level.changemap, "*")) {
+	if (level.changemap && strstr(level.changemap, "*")) {
 		if (coop->integer) {
 			for (auto ec : active_clients()) {
 				// strip players of all keys between units
@@ -3246,9 +3297,21 @@ void ExitLevel() {
 				player->client->pers.lives = g_coop_num_lives->integer + 1;
 	}
 
-	if (level.changemap == nullptr) {
-		gi.Com_Error("Got null changemap when trying to exit level. Was a trigger_changelevel configured correctly?");
-		return;
+	if (!level.changemap || !level.changemap[0]) {
+		const char *context = level.changemap_context[0] ? level.changemap_context : "<no context available>";
+		gi.Com_PrintFmt(
+			"WARNING: Missing changemap when exiting level \'{}\'. Context: {}\n",
+			ChangeLevelDebugValue(level.mapname), context);
+
+		if (level.mapname[0]) {
+			gi.Com_PrintFmt("WARNING: Defaulting to reload current map \'{}\'\n",
+				ChangeLevelDebugValue(level.mapname));
+			level.changemap = level.mapname;
+		} else {
+			gi.Com_PrintFmt(
+				"ERROR: Current level name is empty; aborting level transition to prevent a crash.\n");
+			return;
+		}
 	}
 
 	// for N64 mainly, but if we're directly changing to "victorXXX.pcx" then
@@ -3266,6 +3329,7 @@ void ExitLevel() {
 		gi.AddCommandString(G_Fmt("gamemap \"{}\"\n", level.changemap).data());
 
 	level.changemap = nullptr;
+	level.changemap_context[0] = '\0';
 }
 
 /*


### PR DESCRIPTION
## Summary
- add context tracking for the active changemap so exits can report what triggered the transition
- harden BeginIntermission and CreateTargetChangeLevel to handle missing or empty targets with clear warnings and safe fallbacks
- downgrade the fatal changemap error during ExitLevel to a detailed warning that safely reloads the current map when needed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0ea023bb48328b14aa766dbaf78f2