### PR TITLE
Optimize release build to reduce DLL footprint

### DIFF
--- a/src/game.vcxproj
+++ b/src/game.vcxproj
@@ -65,7 +65,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>KEX_Q2_GAME;KEX_Q2GAME_EXPORTS;KEX_Q2GAME_DYNAMIC;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;NO_FMT_SOURCE;FMT_HEADER_ONLY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>KEX_Q2_GAME;KEX_Q2GAME_EXPORTS;KEX_Q2GAME_DYNAMIC;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
@@ -89,7 +89,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>KEX_Q2_GAME;KEX_Q2GAME_EXPORTS;NO_FMT_SOURCE;KEX_Q2GAME_DYNAMIC;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>KEX_Q2_GAME;KEX_Q2GAME_EXPORTS;KEX_Q2GAME_DYNAMIC;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>
@@ -100,7 +100,9 @@
       <SubSystem>NotSet</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalOptions>/OPT:REF /OPT:ICF %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -160,6 +162,7 @@
     <ClCompile Include="bots\bot_utils.cpp" />
     <ClCompile Include="cg_main.cpp" />
     <ClCompile Include="cg_screen.cpp" />
+    <ClCompile Include="format.cc" />
     <ClCompile Include="g_ai.cpp" />
     <ClCompile Include="g_ai_new.cpp" />
     <ClCompile Include="g_chase.cpp" />
@@ -223,6 +226,7 @@
     <ClCompile Include="p_trail.cpp" />
     <ClCompile Include="p_view.cpp" />
     <ClCompile Include="p_weapon.cpp" />
+    <ClCompile Include="os.cc" />
     <ClCompile Include="q_std.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/game.vcxproj.filters
+++ b/src/game.vcxproj.filters
@@ -131,6 +131,7 @@
   <ItemGroup>
     <ClCompile Include="cg_main.cpp" />
     <ClCompile Include="cg_screen.cpp" />
+    <ClCompile Include="format.cc" />
     <ClCompile Include="g_ai.cpp" />
     <ClCompile Include="g_chase.cpp" />
     <ClCompile Include="g_cmds.cpp" />
@@ -155,6 +156,7 @@
     <ClCompile Include="p_trail.cpp" />
     <ClCompile Include="p_view.cpp" />
     <ClCompile Include="p_weapon.cpp" />
+    <ClCompile Include="os.cc" />
     <ClCompile Include="q_std.cpp" />
     <ClCompile Include="bots\bot_debug.cpp">
       <Filter>bots</Filter>

--- a/src/q_std.cpp
+++ b/src/q_std.cpp
@@ -279,9 +279,6 @@ size_t Q_strlcat(char *dst, const char *src, size_t siz)
     return (dlen + (s - src)); /* count does not include NUL */
 }
 
-#if !defined(USE_CPP20_FORMAT) && !defined(NO_FMT_SOURCE)
-// fmt ugliness because we haven't figured out FMT_INCLUDE_ONLY
-#include "../src/format.cc"
-#endif
+// fmt is compiled as a dedicated translation unit; nothing to include here.
 #endif
 //====================================================================


### PR DESCRIPTION
## Summary
- build fmt as dedicated translation units instead of header-only usage to cut redundant instantiations
- enable link-time code generation and size-focused linker flags for the release configuration
- update project filters so the new sources are visible in the solution

## Testing
- not run (visual studio project)


------
https://chatgpt.com/codex/tasks/task_e_68e0f9b3c544832894f09e57eb57b11b