### PR TITLE
Fix crash when resetting level state by preserving entity string

### DIFF
--- a/src/g_spawn.cpp
+++ b/src/g_spawn.cpp
@@ -1782,8 +1782,7 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
 			//gi.Com_PrintFmt("{}: Entities override file not saved as file already exists: \"{}\"\n", __FUNCTION__, name);
 		}
 	}
-	level.entstring = entities;
-//#endif
+	std::string entity_text{ entities ? entities : "" };
 	//ParseWorldEntityString(mapname, RS(RS_Q3A));
 
 	// clear cached indices
@@ -1799,7 +1798,10 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
 
 	gi.FreeTags(TAG_LEVEL);
 
-	memset(&level, 0, sizeof(level));
+	level = level_locals_t{};
+	level.entstring = std::move(entity_text);
+	entities = level.entstring.c_str();
+
 	memset(g_entities, 0, game.maxentities * sizeof(g_entities[0]));
 	
 	// all other flags are not important atm


### PR DESCRIPTION
## Summary
- copy the incoming entity string before clearing the level state
- replace the raw memset on `level` with value-initialization so `std::string` members stay valid
- restore the copied entity data onto the fresh level object before entity parsing resumes

## Testing
- not run (logic-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0fc65ed648328883bd33f1e0218b2