### PR TITLE
Fix fmt formatter const format methods

### DIFF
--- a/src/g_local.hpp
+++ b/src/g_local.hpp
@@ -4139,7 +4139,7 @@ struct fmt::formatter<gentity_t> {
 	}
 
 	template<typename FormatContext>
-	auto format(const gentity_t &p, FormatContext &ctx) -> decltype(ctx.out()) {
+        auto format(const gentity_t &p, FormatContext &ctx) const -> decltype(ctx.out()) {
 		if (p.linked)
 			return fmt::format_to(ctx.out(), FMT_STRING("{} @ {}"), p.classname, (p.absmax + p.absmin) * 0.5f);
 		return fmt::format_to(ctx.out(), FMT_STRING("{} @ {}"), p.classname, p.s.origin);

--- a/src/q_vec3.h
+++ b/src/q_vec3.h
@@ -536,7 +536,7 @@ template<>
 struct fmt::formatter<vec3_t> : fmt::formatter<float>
 {
     template<typename FormatContext>
-    auto format(const vec3_t &p, FormatContext &ctx) -> decltype(ctx.out())
+    auto format(const vec3_t &p, FormatContext &ctx) const -> decltype(ctx.out())
     {
 		auto out = fmt::formatter<float>::format(p.x, ctx);
         out = fmt::format_to(out, " ");


### PR DESCRIPTION
## Summary
- add const qualifiers to custom fmt formatter format methods to satisfy fmt's formatter requirements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10428313c832895afb336c816c439