### PR TITLE
Reload entstring entities when starting or resetting matches

### DIFF
--- a/src/g_local.hpp
+++ b/src/g_local.hpp
@@ -3058,6 +3058,7 @@ bool InAMatch();
 void ChangeGametype(gametype_t gt);
 void GT_Changes();
 void SpawnEntities(const char *mapname, const char *entities, const char *spawnpoint);
+void Entities_ReloadFromEntstring();
 void G_LoadMOTD();
 
 //

--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -561,10 +561,7 @@ void GT_Changes() {
 		gt_check = (gametype_t)g_gametype->integer;
 	} else return;
 
-	//TODO: save ent string so we can simply reload it and Match_Reset
-	//gi.AddCommandString("map_restart");
-
-	gi.AddCommandString(G_Fmt("gamemap {}\n", level.mapname).data());
+        gi.AddCommandString(G_Fmt("gamemap {}\n", level.mapname).data());
 
 	GT_PrecacheAssets();
 	GT_SetLongName();
@@ -944,10 +941,12 @@ Starts a match
 ============
 */
 void Match_Start() {
-	if (!deathmatch->integer)
-		return;
+        if (!deathmatch->integer)
+                return;
 
-	level.match_time = level.time;
+        Entities_ReloadFromEntstring();
+
+        level.match_time = level.time;
 	level.match_start_time = level.time;
 	level.overtime = 0_sec;
 
@@ -963,10 +962,10 @@ void Match_Start() {
 
 	level.total_player_deaths = 0;
 
-	memset(level.ghosts, 0, sizeof(level.ghosts));
+        memset(level.ghosts, 0, sizeof(level.ghosts));
 
-	Entities_Reset(true, true, true);
-	UnReadyAll();
+        Entities_Reset(true, true, true);
+        UnReadyAll();
 
 	SetMatchID();
 
@@ -993,6 +992,8 @@ void Match_Reset() {
 	//	Match_Start();
 	//	return;
 	//}
+
+	Entities_ReloadFromEntstring();
 
 	Entities_Reset(true, true, true);
 	UnReadyAll();


### PR DESCRIPTION
## Summary
- add an `Entities_ReloadFromEntstring` helper that frees level-tagged allocations, clears non-client entities, and respawns the map from the cached entstring
- call the new helper when beginning a match or issuing a match reset so multiplayer sessions start from a clean world state
- expose the helper in the shared game header for reuse

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e10235a0088328984d1233929b0233