### PR TITLE
Fix vote command crash from empty argument string

### DIFF
--- a/src/g_cmds.cpp
+++ b/src/g_cmds.cpp
@@ -2738,7 +2738,8 @@ void VoteCommandStore(gentity_t *ent) {
 	level.vote_yes = 1;
 	level.vote_no = 0;
 	
-	gi.LocBroadcast_Print(PRINT_CENTER, "{} called a vote:\n{}{}\n", level.vote_client->resp.netname, level.vote->name, level.vote_arg[0] ? G_Fmt(" {}", level.vote_arg).data() : "");
+        const char *vote_suffix = level.vote_arg.empty() ? "" : G_Fmt(" {}", level.vote_arg).data();
+        gi.LocBroadcast_Print(PRINT_CENTER, "{} called a vote:\n{}{}\n", level.vote_client->resp.netname, level.vote->name, vote_suffix);
 
 	for (auto ec : active_clients())
 		ec->client->pers.voted = ec == ent ? 1 : 0;

--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -639,8 +639,8 @@ static void InitGame() {
 
 	*level.weapon_count = { 0 };
 
-	level.vote = nullptr;
-	level.vote_arg = '\n';
+        level.vote = nullptr;
+        level.vote_arg.clear();
 
 	level.total_player_deaths = 0;
 


### PR DESCRIPTION
## Summary
- avoid dereferencing an empty vote argument string when broadcasting vote announcements
- reset vote arguments to an empty value during level initialization instead of a stray newline

## Testing
- not run (reason: not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e106b81ea48328aa245f2566967453