### PR TITLE
Guard ban disconnects when client not connected

### DIFF
--- a/src/p_client.cpp
+++ b/src/p_client.cpp
@@ -3499,14 +3499,15 @@ static inline bool CheckBanned(gentity_t *ent, char *userinfo, const char *socia
 			}
 		}
 
-		gi.local_sound(ent, CHAN_AUTO, gi.soundindex("world/klaxon3.wav"), 1, ATTN_NONE, 0);
-		gi.AddCommandString(G_Fmt("kick {}\n", ent - g_entities - 1).data());
-		G_StuffCmd(ent, "disconnect\n");
-		return true;
-	}
+                gi.local_sound(ent, CHAN_AUTO, gi.soundindex("world/klaxon3.wav"), 1, ATTN_NONE, 0);
+                gi.AddCommandString(G_Fmt("kick {}\n", ent - g_entities - 1).data());
+                if (ent->client->pers.connected)
+                        G_StuffCmd(ent, "disconnect\n");
+                return true;
+        }
 
-	// Model192
-	if (!Q_strcasecmp(social_id, "Steamworks-76561197972296343")) {
+        // Model192
+        if (!Q_strcasecmp(social_id, "Steamworks-76561197972296343")) {
 		gi.Info_SetValueForKey(userinfo, "rejmsg", "WARNING! MOANERTONE DETECTED\n");
 
 		gentity_t *host = &g_entities[1];
@@ -3522,14 +3523,15 @@ static inline bool CheckBanned(gentity_t *ent, char *userinfo, const char *socia
 			}
 		}
 
-		gi.local_sound(ent, CHAN_AUTO, gi.soundindex("world/klaxon3.wav"), 1, ATTN_NONE, 0);
-		gi.AddCommandString(G_Fmt("kick {}\n", ent - g_entities - 1).data());
-		G_StuffCmd(ent, "disconnect\n");
-		return true;
-	}
+                gi.local_sound(ent, CHAN_AUTO, gi.soundindex("world/klaxon3.wav"), 1, ATTN_NONE, 0);
+                gi.AddCommandString(G_Fmt("kick {}\n", ent - g_entities - 1).data());
+                if (ent->client->pers.connected)
+                        G_StuffCmd(ent, "disconnect\n");
+                return true;
+        }
 
-	// Dalude
-	if (!Q_strcasecmp(social_id, "Steamworks-76561199001991246") || !Q_strcasecmp(social_id, "EOS-07e230c273be4248bbf26c89033923c1")) {
+        // Dalude
+        if (!Q_strcasecmp(social_id, "Steamworks-76561199001991246") || !Q_strcasecmp(social_id, "EOS-07e230c273be4248bbf26c89033923c1")) {
 		ent->client->sess.is_888 = true;
 		gi.Info_SetValueForKey(userinfo, "rejmsg", "Fake 888 Agent detected!\n");
 		gi.Info_SetValueForKey(userinfo, "name", "Fake 888 Agent");
@@ -3546,11 +3548,12 @@ static inline bool CheckBanned(gentity_t *ent, char *userinfo, const char *socia
 				gi.LocBroadcast_Print(PRINT_CHAT, "{}: bejesus, what a lovely lobby! certainly better than 888's!\n", name);
 			}
 		}
-		gi.local_sound(ent, CHAN_AUTO, gi.soundindex("world/klaxon3.wav"), 1, ATTN_NONE, 0);
-		gi.AddCommandString(G_Fmt("kick {}\n", ent - g_entities - 1).data());
-		G_StuffCmd(ent, "disconnect\n");
-		return true;
-	}
+                gi.local_sound(ent, CHAN_AUTO, gi.soundindex("world/klaxon3.wav"), 1, ATTN_NONE, 0);
+                gi.AddCommandString(G_Fmt("kick {}\n", ent - g_entities - 1).data());
+                if (ent->client->pers.connected)
+                        G_StuffCmd(ent, "disconnect\n");
+                return true;
+        }
 	return false;
 }
 


### PR DESCRIPTION
## Summary
- guard Kirlomax, Model192, and Dalude ban handlers against calling G_StuffCmd on clients that have not finished connecting
- rely on the existing kick command once the disconnect stufftext is skipped for unconnected clients

## Testing
- not run (server binary unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e42bec7214832883c8c4bd3600dc21