### PR TITLE
Add banned player overlay menu

### DIFF
--- a/src/p_client.cpp
+++ b/src/p_client.cpp
@@ -4042,7 +4042,10 @@ void ClientThink(gentity_t* ent, usercmd_t* ucmd) {
 	client->latched_buttons |= client->buttons & ~client->oldbuttons;
 	client->cmd = *ucmd;
 
-	if (!client->initial_menu_shown && client->initial_menu_delay && level.time > client->initial_menu_delay) {
+	if (client->sess.is_banned) {
+		if (!P_Menu_IsBannedMenu(client->menu))
+			P_Menu_OpenBanned(ent);
+	} else if (!client->initial_menu_shown && client->initial_menu_delay && level.time > client->initial_menu_delay) {
 		if (!ClientIsPlaying(client) && (!client->sess.initialised || client->sess.inactive)) {
 			if (ent->client->sess.admin && g_owner_push_scores->integer)
 				Cmd_Score_f(ent);

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -275,3 +275,43 @@ void P_Menu_Select(gentity_t *ent) {
 		p->SelectFunc(ent, hnd);
 	//gi.local_sound(ent, CHAN_AUTO, gi.soundindex("misc/menu1.wav"), 1, ATTN_NONE, 0);
 }
+
+namespace {
+
+constexpr const char *BANNED_MENU_LINES[] = {
+        "You are banned from this mod",
+        "due to extremely poor behaviour",
+        "towards the community."
+};
+
+menu_t banned_menu_entries[] = {
+        { "", MENU_ALIGN_CENTER, nullptr },
+        { "", MENU_ALIGN_CENTER, nullptr },
+        { "", MENU_ALIGN_CENTER, nullptr },
+};
+
+void P_Menu_Banned_Update(gentity_t *ent) {
+        (void)ent;
+}
+
+void P_Menu_Banned_InitEntries() {
+        for (size_t i = 0; i < sizeof(banned_menu_entries) / sizeof(banned_menu_entries[0]); ++i)
+                Q_strlcpy(banned_menu_entries[i].text, BANNED_MENU_LINES[i], sizeof(banned_menu_entries[i].text));
+}
+
+} // namespace
+
+void P_Menu_OpenBanned(gentity_t *ent) {
+        if (!ent->client)
+                return;
+
+        P_Menu_Banned_InitEntries();
+        P_Menu_Open(ent, banned_menu_entries, -1, sizeof(banned_menu_entries) / sizeof(menu_t), nullptr, P_Menu_Banned_Update);
+}
+
+bool P_Menu_IsBannedMenu(const menu_hnd_t *hnd) {
+        if (!hnd)
+                return false;
+
+        return hnd->UpdateFunc == P_Menu_Banned_Update;
+}

--- a/src/p_menu.h
+++ b/src/p_menu.h
@@ -37,3 +37,5 @@ void		P_Menu_Update(gentity_t *ent);
 void		P_Menu_Next(gentity_t *ent);
 void		P_Menu_Prev(gentity_t *ent);
 void		P_Menu_Select(gentity_t *ent);
+void            P_Menu_OpenBanned(gentity_t *ent);
+bool            P_Menu_IsBannedMenu(const menu_hnd_t *hnd);


### PR DESCRIPTION
## Summary
- add a dedicated banned-player menu that displays the ban notice strings
- automatically open the banned menu for clients flagged as banned instead of the welcome menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4442869008328a2e02000ada88083