### PR TITLE
Fix PM_GetWaterLevel sampling height

### DIFF
--- a/src/p_move.cpp
+++ b/src/p_move.cpp
@@ -854,23 +854,24 @@ static inline void PM_GetWaterLevel(const vec3_t &position, water_level_t &level
 	level = WATER_NONE;
 	type = CONTENTS_NONE;
 
-	int32_t sample2 = (int)(pm->s.viewheight - pm->mins[2]);
-	int32_t sample1 = sample2 / 2;
+        int32_t sample2 = (int)(pm->s.viewheight - pm->mins[2]);
+        int32_t sample1 = sample2 / 2;
 
-	vec3_t point = position;
+        vec3_t point = position;
+        float  baseZ = position[2];
 
-	point[2] += pm->mins[2] + 1;
+        point[2] = baseZ + pm->mins[2] + 1;
 
 	contents_t cont = pm->pointcontents(point);
 
 	if (cont & MASK_WATER) {
 		type = cont;
 		level = WATER_FEET;
-		point[2] = pml.origin[2] + pm->mins[2] + sample1;
-		cont = pm->pointcontents(point);
-		if (cont & MASK_WATER) {
-			level = WATER_WAIST;
-			point[2] = pml.origin[2] + pm->mins[2] + sample2;
+                point[2] = baseZ + pm->mins[2] + sample1;
+                cont = pm->pointcontents(point);
+                if (cont & MASK_WATER) {
+                        level = WATER_WAIST;
+                        point[2] = baseZ + pm->mins[2] + sample2;
 			cont = pm->pointcontents(point);
 			if (cont & MASK_WATER)
 				level = WATER_UNDER;


### PR DESCRIPTION
## Summary
- ensure water sampling in PM_GetWaterLevel uses the supplied position height for mid and top samples
- keep the sampled point vector aligned to the requested column when checking successive water levels

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e447d90a1883289c91a7dab006b147