### PR TITLE
Restore legacy pmove snapping around the world origin

### DIFF
--- a/src/p_move.cpp
+++ b/src/p_move.cpp
@@ -427,8 +427,8 @@ static void PM_StepSlideMove() {
 	down_o = pml.origin;
 	down_v = pml.velocity;
 	
-	up = start_o;
-	up[2] += (pml.origin[2] < 0) ? STEPSIZE_BELOW : STEPSIZE;
+        up = start_o;
+        up[2] += STEPSIZE;
 
 	trace = PM_Trace(start_o, pm->mins, pm->maxs, up);
 	if (trace.allsolid)
@@ -484,10 +484,10 @@ static void PM_StepSlideMove() {
 		pml.velocity[2] = down_v[2];
 
 	// Paril: step down stairs/slopes
-	if ((pm->s.pm_flags & PMF_ON_GROUND) && !(pm->s.pm_flags & PMF_ON_LADDER) &&
-		(pm->waterlevel < WATER_WAIST || (!(pm->cmd.buttons & BUTTON_JUMP) && pml.velocity.z <= 0))) {
-		down = pml.origin;
-		down[2] -= (pml.origin[2] < 0) ? STEPSIZE_BELOW : STEPSIZE;
+        if ((pm->s.pm_flags & PMF_ON_GROUND) && !(pm->s.pm_flags & PMF_ON_LADDER) &&
+                (pm->waterlevel < WATER_WAIST || (!(pm->cmd.buttons & BUTTON_JUMP) && pml.velocity.z <= 0))) {
+                down = pml.origin;
+                down[2] -= STEPSIZE;
 		trace = PM_Trace(pml.origin, pm->mins, pm->maxs, down);
 		if (trace.fraction < 1.f) {
 			pml.origin = trace.endpos;
@@ -998,10 +998,7 @@ static void PM_CheckJump() {
 	pm->groundentity = nullptr;
 	pm->s.pm_flags &= ~PMF_ON_GROUND;
 
-	float jump_height = 270.f;
-
-	if (pml.origin[2] < 0)
-		jump_height += 4.0f;
+        float jump_height = 270.f;
 
 	pml.velocity[2] = ceil(pml.velocity[2] + jump_height);
 	if (pml.velocity[2] < jump_height)
@@ -1087,8 +1084,8 @@ static void PM_CheckSpecialMovement() {
 
 	// we're currently standing on ground, and the snapped position
 	// is a step
-	if (pm->groundentity && fabsf(pml.origin.z - trace.endpos.z) <= ((pml.origin[2] < 0) ? STEPSIZE_BELOW : STEPSIZE))
-		return;
+        if (pm->groundentity && fabsf(pml.origin.z - trace.endpos.z) <= STEPSIZE)
+                return;
 
 	water_level_t level;
 	contents_t type;
@@ -1328,6 +1325,15 @@ bool PM_GoodPosition() {
 	return !trace.allsolid;
 }
 
+static vec3_t PM_SnapToLegacyGrid(const vec3_t &value) {
+        vec3_t snapped{};
+
+        for (size_t i = 0; i < 3; i++)
+                snapped[i] = (float)((int32_t)(value[i] * 8.0f)) * 0.125f;
+
+        return snapped;
+}
+
 /*
 ================
 PM_SnapPosition
@@ -1337,8 +1343,11 @@ precision of the network channel and in a valid position.
 ================
 */
 static void PM_SnapPosition() {
-	pm->s.velocity = pml.velocity;
-	pm->s.origin = pml.origin;
+        pml.origin = PM_SnapToLegacyGrid(pml.origin);
+        pml.velocity = PM_SnapToLegacyGrid(pml.velocity);
+
+        pm->s.velocity = pml.velocity;
+        pm->s.origin = pml.origin;
 
 	if (PM_GoodPosition())
 		return;


### PR DESCRIPTION
## Summary
- snap pmove origin and velocity back to the legacy Quake II 1/8th unit grid before exporting state
- rely on the existing stuck resolution and remove the custom z<0 stair, jump, and waterjump allowances that are no longer needed

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e44840602883289ce9c34476306be2