### PR TITLE
Reduce release DLL size by using header-only fmt

### DIFF
--- a/src/game.vcxproj
+++ b/src/game.vcxproj
@@ -89,7 +89,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>KEX_Q2_GAME;KEX_Q2GAME_EXPORTS;NO_FMT_SOURCE;KEX_Q2GAME_DYNAMIC;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>KEX_Q2_GAME;KEX_Q2GAME_EXPORTS;NO_FMT_SOURCE;FMT_HEADER_ONLY;KEX_Q2GAME_DYNAMIC;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DisableSpecificWarnings>4267;4244</DisableSpecificWarnings>

--- a/src/q_std.h
+++ b/src/q_std.h
@@ -33,6 +33,9 @@
 namespace fmt = std;
 #define FMT_STRING(s) s
 #else
+#ifndef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
+#endif
 #include <fmt/format.h>
 #endif
 


### PR DESCRIPTION
## Summary
- define `FMT_HEADER_ONLY` in the release build so fmt stays header-only
- add a defensive default for `FMT_HEADER_ONLY` in `q_std.h` to prevent linking the compiled fmt library

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913ab8130f8832890214d3bf728c26a)