### PR TITLE
Fix map list shuffle format usage

### DIFF
--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -2994,7 +2994,8 @@ void Match_End() {
 							if (values[0] == level.mapname)
 								std::swap(values[0], values[values.size() - 1]);
 
-							gi.cvar_forceset("g_map_list", fmt::format("{}", join_strings(values, " ")).data());
+						auto shuffled_map_list = join_strings(values, " ");
+						gi.cvar_forceset("g_map_list", shuffled_map_list.c_str());
 
 							BeginIntermission(CreateTargetChangeLevel(values[0].c_str()));
 							return;


### PR DESCRIPTION
## Summary
- avoid unnecessary fmt::format when updating the shuffled map list
- store the joined map list string before forcing the cvar value to keep the data alive

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163a45dc0c8328ad97add38f60c451)