### PR TITLE
Ensure override checks see updated map name

### DIFF
--- a/src/g_spawn.cpp
+++ b/src/g_spawn.cpp
@@ -1691,6 +1691,13 @@ parsing textual entity definitions out of an ent file.
 void SpawnEntities(const char *mapname, const char *entities, const char *spawnpoint) {
 	bool		ent_file_exists = false, ent_valid = true;
 	//const char	*entities = level.entstring.c_str();
+
+	Q_strlcpy(level.mapname, mapname, sizeof(level.mapname));
+	// Paril: fixes a bug where autosaves will start you at
+	// the wrong spawnpoint if they happen to be non-empty
+	// (mine2 -> mine3)
+	if (!game.autosaved)
+		Q_strlcpy(game.spawnpoint, spawnpoint, sizeof(game.spawnpoint));
 //#if 0
 	// load up ent override
 	//const char *name = G_Fmt("baseq2/maps/{}.ent", mapname).data();
@@ -1773,13 +1780,6 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
 	
 	// all other flags are not important atm
 	globals.server_flags &= SERVER_FLAG_LOADING;
-
-	Q_strlcpy(level.mapname, mapname, sizeof(level.mapname));
-	// Paril: fixes a bug where autosaves will start you at
-	// the wrong spawnpoint if they happen to be non-empty
-	// (mine2 -> mine3)
-	if (!game.autosaved)
-		Q_strlcpy(game.spawnpoint, spawnpoint, sizeof(game.spawnpoint));
 
 	level.is_n64 = strncmp(level.mapname, "q64/", 4) == 0;
 


### PR DESCRIPTION
## Summary
- move the `level.mapname`/`game.spawnpoint` updates to the start of `SpawnEntities` so the entity override load/save logic always sees the new map name

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dae51b3f48326971c4d74781e837d)