### PR TITLE
Reset num_entities after clearing entity array

### DIFF
--- a/src/g_spawn.cpp
+++ b/src/g_spawn.cpp
@@ -1769,7 +1769,8 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
 	gi.FreeTags(TAG_LEVEL);
 
 	memset(&level, 0, sizeof(level));
-	memset(g_entities, 0, game.maxentities * sizeof(g_entities[0]));
+memset(g_entities, 0, game.maxentities * sizeof(g_entities[0]));
+globals.num_entities = game.maxclients + 1;
 	
 	// all other flags are not important atm
 	globals.server_flags &= SERVER_FLAG_LOADING;


### PR DESCRIPTION
## Summary
- reset `globals.num_entities` after clearing the global entity array so the next level load starts from a clean entity list
- rely on the existing `G_Spawn` allocation path to grow `num_entities` as new entities are spawned, ensuring loops and save code stay bounded to real entities

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dae55f73c83269a10018747ab66fe)