### PR TITLE
Add helper to reset level struct safely

### DIFF
--- a/src/g_spawn.cpp
+++ b/src/g_spawn.cpp
@@ -1681,6 +1681,20 @@ void ClearWorldEntities() {
 }
 
 /*
+=============
+ResetLevelState
+
+Value-initializes the global level state and reapplies defaults for
+non-trivial members.
+=============
+*/
+static void ResetLevelState() {
+	level = level_locals_t{};
+	level.monsters_registered.fill(nullptr);
+	level.health_bar_entities.fill(nullptr);
+}
+
+/*
 ==============
 SpawnEntities
 
@@ -1768,7 +1782,7 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
 
 	gi.FreeTags(TAG_LEVEL);
 
-	memset(&level, 0, sizeof(level));
+	ResetLevelState();
 	memset(g_entities, 0, game.maxentities * sizeof(g_entities[0]));
 	
 	// all other flags are not important atm


### PR DESCRIPTION
## Summary
- add a ResetLevelState helper that value-initializes the global level struct so complex members like std::string and std::array are rebuilt safely
- call the helper from SpawnEntities instead of using memset

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dae53e4208326aab3b63b8911c928)