### PR TITLE
Fix intermission angles

### DIFF
--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -2246,8 +2246,7 @@ void FindIntermissionPoint(void) {
 			if (target) {
 				gi.Com_Print("FindIntermissionPoint target 2\n");
 				dir = (target->s.origin - level.intermission_origin).normalized();
-				AngleVectors(dir);
-				level.intermission_angle = dir;
+				level.intermission_angle = vectoangles(dir);
 			}
 		}
 	}
@@ -2305,8 +2304,7 @@ void SetIntermissionPoint(void) {
 			if (target) {
 				//gi.Com_Print("HAS TARGET\n");
 				vec3_t	dir = (target->s.origin - level.intermission_origin).normalized();
-				AngleVectors(dir);
-				level.intermission_angle = dir;
+				level.intermission_angle = vectoangles(dir);
 			}
 		}
 		if (ent && !level.intermission_angle)


### PR DESCRIPTION
## Summary
- replace the no-op AngleVectors(dir) pattern in FindIntermissionPoint with an actual vector-to-angle conversion so legacy intermission targets orient correctly
- make the same adjustment in SetIntermissionPoint so current intermission spawn targets also respect their facing direction

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dae5fe7508326a02514e332138b62)