### PR TITLE
Fix TagMalloc tags in load paths

### DIFF
--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -544,6 +544,13 @@ static bool Horde_AllMonstersDead() {
 // =================================================
 
 
+/*
+=============
+G_LoadMOTD
+
+Loads the server message of the day text into persistent memory.
+=============
+*/
 void G_LoadMOTD() {
 	// load up ent override
 	const char *name = G_Fmt("baseq2/{}", g_motd_filename->string[0] ? g_motd_filename->string : "motd.txt").data();
@@ -563,7 +570,7 @@ void G_LoadMOTD() {
 			valid = false;
 		}
 		if (valid) {
-			buffer = (char *)gi.TagMalloc(length + 1, '\0');
+			buffer = (char *)gi.TagMalloc(length + 1, TAG_GAME);
 			if (length) {
 				read_length = fread(buffer, 1, length, f);
 
@@ -572,9 +579,10 @@ void G_LoadMOTD() {
 					valid = false;
 				}
 			}
+			buffer[length] = '\0';
 		}
 		fclose(f);
-		
+
 		if (valid) {
 			game.motd = (const char *)buffer;
 			game.motd_mod_count++;
@@ -582,9 +590,12 @@ void G_LoadMOTD() {
 				gi.Com_PrintFmt("{}: MotD file verified and loaded: \"{}\"\n", __FUNCTION__, name);
 		} else {
 			gi.Com_PrintFmt("{}: MotD file load error for \"{}\", discarding.\n", __FUNCTION__, name);
+			if (buffer)
+				gi.TagFree(buffer);
 		}
 	}
 }
+
 
 int check_ruleset = -1;
 static void CheckRuleset() {

--- a/src/g_spawn.cpp
+++ b/src/g_spawn.cpp
@@ -1547,6 +1547,13 @@ static void G_LocateSpawnSpots(void) {
 	level.num_spawn_spots = n;
 }
 
+/*
+=============
+ParseWorldEntityString
+
+Loads an entity override file and applies it to the current map if valid.
+=============
+*/
 static void ParseWorldEntityString(const char *mapname, bool try_q3) {
 	bool	ent_file_exists = false, ent_valid = true;
 	const char *entities = level.entstring.c_str();
@@ -1568,7 +1575,7 @@ static void ParseWorldEntityString(const char *mapname, bool try_q3) {
 			ent_valid = false;
 		}
 		if (ent_valid) {
-			buffer = (char *)gi.TagMalloc(length + 1, '\0');
+			buffer = (char *)gi.TagMalloc(length + 1, TAG_LEVEL);
 			if (length) {
 				read_length = fread(buffer, 1, length, f);
 
@@ -1577,6 +1584,7 @@ static void ParseWorldEntityString(const char *mapname, bool try_q3) {
 					ent_valid = false;
 				}
 			}
+			buffer[length] = '\0';
 		}
 		ent_file_exists = true;
 		fclose(f);
@@ -1710,7 +1718,7 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
 			ent_valid = false;
 		}
 		if (ent_valid) {
-			buffer = (char *)gi.TagMalloc(length + 1, '\0');
+			buffer = (char *)gi.TagMalloc(length + 1, TAG_LEVEL);
 			if (length) {
 				read_length = fread(buffer, 1, length, f);
 
@@ -1719,6 +1727,7 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
 					ent_valid = false;
 				}
 			}
+			buffer[length] = '\0';
 		}
 		ent_file_exists = true;
 		fclose(f);

--- a/src/p_client.cpp
+++ b/src/p_client.cpp
@@ -273,7 +273,7 @@ static void PCfg_ClientInitPConfig(gentity_t* ent) {
 			cfg_valid = false;
 		}
 		if (cfg_valid) {
-			buffer = (char*)gi.TagMalloc(length + 1, '\0');
+			buffer = (char*)gi.TagMalloc(length + 1, TAG_GAME);
 			if (length) {
 				read_length = fread(buffer, 1, length, f);
 
@@ -281,6 +281,7 @@ static void PCfg_ClientInitPConfig(gentity_t* ent) {
 					cfg_valid = false;
 				}
 			}
+			buffer[length] = '\0';
 		}
 		file_exists = true;
 		fclose(f);


### PR DESCRIPTION
## Summary
- tag per-map entity override buffers with TAG_LEVEL and document the loader so they are released with level memory
- load persistent files (player configs and MotD) with TAG_GAME, add null terminators, and free invalid buffers to avoid leaks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dae57bec483269c1f877bec4d655b)