### PR TITLE
Fix team balancing loop guard

### DIFF
--- a/src/g_cmds.cpp
+++ b/src/g_cmds.cpp
@@ -1927,11 +1927,16 @@ int TeamBalance(bool force) {
 	qsort(index, count, sizeof(index[0]), PlayerSortByJoinTime);
 
 	//run through sort list, switching from stack_team until teams are even
+	if (!count) {
+		gi.LocBroadcast_Print(PRINT_HIGH, "Team balance skipped: no stacked players available.\n");
+		return 0;
+	}
+
 	if (count) {
 		size_t	i;
 		int switched = 0;
 		gclient_t *cl = nullptr;
-		for (i = 0; i < count, delta > 1; i++) {
+		for (i = 0; i < count && delta > 1; i++) {
 			cl = &game.clients[index[i]];
 
 			if (!cl)


### PR DESCRIPTION
## Summary
- add an early return with logging when no stacked players are available for balancing
- update the team balancing loop condition to stop when the player list is exhausted or teams are balanced

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e24ea84ec83268a616589e940b070)