### PR TITLE
Defer team balance during rounds

### DIFF
--- a/src/g_local.h
+++ b/src/g_local.h
@@ -2531,6 +2531,7 @@ team_t PickTeam(int ignoreClientNum);
 void BroadcastTeamChange(gentity_t *ent, int old_team, bool inactive, bool silent);
 bool AllowClientTeamSwitch(gentity_t *ent);
 int TeamBalance(bool force);
+void ProcessBalanceQueue(void);
 void Cmd_ReadyUp_f(gentity_t *ent);
 
 void VoteCommandStore(gentity_t *ent);

--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -1469,6 +1469,8 @@ void Round_End() {
 	level.round_state = roundst_t::ROUND_ENDED;
 	level.round_state_timer = level.time + 3_sec;
 	level.horde_all_spawned = false;
+
+	ProcessBalanceQueue();
 }
 
 /*


### PR DESCRIPTION
## Summary
- add a queue for requested balance team changes and track pending requests during round-based play
- defer TeamBalance changes during active rounds and apply them once the round has ended
- expose balance queue processing and run it when a round concludes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e24ed2ae083269864099e800cce4f)