### PR TITLE
Handle null trigger activators safely

### DIFF
--- a/src/g_activation.cpp
+++ b/src/g_activation.cpp
@@ -1,0 +1,32 @@
+#include "g_activation.h"
+
+/*
+=============
+BuildActivationMessagePlan
+
+Creates an activation message plan for the provided context.
+=============
+*/
+activation_message_plan_t BuildActivationMessagePlan(bool has_message, bool has_activator, bool activator_is_monster, bool coop_global, bool coop_enabled, int noise_index)
+{
+	activation_message_plan_t plan;
+
+	if (!has_message)
+		return plan;
+
+	if (coop_global && coop_enabled)
+		plan.broadcast_global = true;
+
+	if (!has_activator || activator_is_monster)
+		return plan;
+
+	plan.center_on_activator = true;
+
+	if (noise_index >= 0)
+	{
+		plan.play_sound = true;
+		plan.sound_index = noise_index;
+	}
+
+	return plan;
+}

--- a/src/g_activation.h
+++ b/src/g_activation.h
@@ -1,0 +1,25 @@
+/*
+=============
+BuildActivationMessagePlan
+
+Defines the information needed to safely emit activation messaging and sounds.
+=============
+*/
+#pragma once
+
+struct activation_message_plan_t
+{
+	bool broadcast_global = false;
+	bool center_on_activator = false;
+	bool play_sound = false;
+	int sound_index = -1;
+};
+
+/*
+=============
+BuildActivationMessagePlan
+
+Creates an activation message plan for the provided context.
+=============
+*/
+activation_message_plan_t BuildActivationMessagePlan(bool has_message, bool has_activator, bool activator_is_monster, bool coop_global, bool coop_enabled, int noise_index);

--- a/src/g_utils.cpp
+++ b/src/g_utils.cpp
@@ -2,6 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_utils.c -- misc utility functions for game module
 
+#include "g_activation.h"
 #include "g_local.h"
 #include <cerrno>
 
@@ -110,23 +111,38 @@ static THINK(Think_Delay) (gentity_t *ent) -> void {
 	G_FreeEntity(ent);
 }
 
-void G_PrintActivationMessage(gentity_t *ent, gentity_t *activator, bool coop_global) {
-	//
-	// print the message
-	//
-	if ((ent->message) && !(activator->svflags & SVF_MONSTER)) {
-		if (coop_global && coop->integer)
-			gi.LocBroadcast_Print(PRINT_CENTER, "{}", ent->message);
-		else
-			gi.LocCenter_Print(activator, "{}", ent->message);
+/*
+=============
+G_PrintActivationMessage
 
-		// [Paril-KEX] allow non-noisy centerprints
-		if (ent->noise_index >= 0) {
-			if (ent->noise_index)
-				gi.sound(activator, CHAN_AUTO, ent->noise_index, 1, ATTN_NORM, 0);
-			else
-				gi.sound(activator, CHAN_AUTO, gi.soundindex("misc/talk1.wav"), 1, ATTN_NORM, 0);
-		}
+Prints activation messaging and plays optional sounds when an entity is used.
+=============
+*/
+void G_PrintActivationMessage(gentity_t *ent, gentity_t *activator, bool coop_global) {
+	if (!ent || !ent->message)
+		return;
+
+	const bool has_activator = activator != nullptr;
+	const bool activator_is_monster = has_activator && (activator->svflags & SVF_MONSTER);
+	const activation_message_plan_t plan = BuildActivationMessagePlan(true, has_activator, activator_is_monster, coop_global, coop->integer, ent->noise_index);
+
+	if (!plan.broadcast_global && !plan.center_on_activator)
+		return;
+
+	if (plan.broadcast_global)
+		gi.LocBroadcast_Print(PRINT_CENTER, "{}", ent->message);
+
+	if (!has_activator || !plan.center_on_activator)
+		return;
+
+	gi.LocCenter_Print(activator, "{}", ent->message);
+
+	// [Paril-KEX] allow non-noisy centerprints
+	if (plan.play_sound) {
+		if (plan.sound_index)
+			gi.sound(activator, CHAN_AUTO, plan.sound_index, 1, ATTN_NORM, 0);
+		else
+			gi.sound(activator, CHAN_AUTO, gi.soundindex("misc/talk1.wav"), 1, ATTN_NORM, 0);
 	}
 }
 

--- a/src/game.vcxproj
+++ b/src/game.vcxproj
@@ -107,6 +107,7 @@
     <ClInclude Include="bots\bot_utils.h" />
     <ClInclude Include="cg_local.h" />
     <ClInclude Include="game.h" />
+    <ClInclude Include="g_activation.h" />
     <ClInclude Include="g_local.h" />
     <ClInclude Include="g_statusbar.h" />
     <ClInclude Include="monsters\m_actor.h" />
@@ -173,6 +174,7 @@
     <ClCompile Include="g_svcmds.cpp" />
     <ClCompile Include="g_target.cpp" />
     <ClCompile Include="g_trigger.cpp" />
+    <ClCompile Include="g_activation.cpp" />
     <ClCompile Include="g_turret.cpp" />
     <ClCompile Include="g_utils.cpp" />
     <ClCompile Include="g_weapon.cpp" />

--- a/src/game.vcxproj.filters
+++ b/src/game.vcxproj.filters
@@ -6,6 +6,7 @@
     <ClInclude Include="g_local.h" />
     <ClInclude Include="g_statusbar.h" />
     <ClInclude Include="game.h" />
+    <ClInclude Include="g_activation.h" />
     <ClInclude Include="q_std.h" />
     <ClInclude Include="q_vec3.h" />
     <ClInclude Include="bots\bot_debug.h">
@@ -145,6 +146,7 @@
     <ClCompile Include="g_svcmds.cpp" />
     <ClCompile Include="g_target.cpp" />
     <ClCompile Include="g_trigger.cpp" />
+    <ClCompile Include="g_activation.cpp" />
     <ClCompile Include="g_turret.cpp" />
     <ClCompile Include="g_utils.cpp" />
     <ClCompile Include="g_weapon.cpp" />

--- a/tests/activation_message_tests.cpp
+++ b/tests/activation_message_tests.cpp
@@ -1,0 +1,30 @@
+#include "../src/g_activation.h"
+#include <cassert>
+
+/*
+=============
+main
+
+Regression coverage for activation message planning.
+=============
+*/
+int main()
+{
+	activation_message_plan_t no_activator_broadcast = BuildActivationMessagePlan(true, false, false, true, true, 5);
+	assert(no_activator_broadcast.broadcast_global);
+	assert(!no_activator_broadcast.center_on_activator);
+	assert(!no_activator_broadcast.play_sound);
+
+	activation_message_plan_t no_activator_silent = BuildActivationMessagePlan(true, false, false, false, true, 2);
+	assert(!no_activator_silent.broadcast_global);
+	assert(!no_activator_silent.center_on_activator);
+	assert(!no_activator_silent.play_sound);
+
+	activation_message_plan_t player_plan = BuildActivationMessagePlan(true, true, false, false, true, 0);
+	assert(!player_plan.broadcast_global);
+	assert(player_plan.center_on_activator);
+	assert(player_plan.play_sound);
+	assert(player_plan.sound_index == 0);
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- guard activation messaging so triggers without activators no longer dereference null and still broadcast coop messages when appropriate
- extract activation message planning into a reusable helper
- add a regression test covering activation without a player activator

## Testing
- g++ -std=c++17 tests/activation_message_tests.cpp src/g_activation.cpp -o /tmp/activation_test
- /tmp/activation_test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e24f861388326899bb37195d74fc3)