### PR TITLE
Handle invalid save data lookups

### DIFF
--- a/src/g_save.cpp
+++ b/src/g_save.cpp
@@ -60,6 +60,13 @@ static std::unordered_map<std::tuple<const void *, save_data_tag_t>, const save_
 
 #include <cassert>
 
+/*
+=============
+InitSave
+
+Initializes the save data lists and validates for duplicates.
+=============
+*/
 void InitSave() {
 	if (save_data_initialized)
 		return;
@@ -102,19 +109,31 @@ void InitSave() {
 
 	save_data_initialized = true;
 }
-
 // initializer for save data
-save_data_list_t::save_data_list_t(const char *name_in, save_data_tag_t tag_in, const void *ptr_in) :
+/*
+=============
+save_data_list_t::save_data_list_t(const char *name_in, save_data_tag_t tag_in, const void *ptr_in, bool link, bool valid_in) :
 	name(name_in),
 	tag(tag_in),
-	ptr(ptr_in) {
-	if (save_data_initialized)
+	ptr(ptr_in),
+	next(nullptr),
+	valid(valid_in) {
+	if (save_data_initialized && link)
 		gi.Com_Error("attempted to create save_data_list at runtime");
 
-	next = list_head;
-	list_head = this;
+	if (link) {
+		next = list_head;
+		list_head = this;
+	}
 }
 
+/*
+=============
+save_data_list_t::fetch
+
+Fetches a save data entry for a pointer/tag pair, returning a sentinel when missing.
+=============
+*/
 const save_data_list_t *save_data_list_t::fetch(const void *ptr, save_data_tag_t tag) {
 	auto link = list_from_ptr_hash.find(std::make_tuple(ptr, tag));
 
@@ -129,7 +148,12 @@ const save_data_list_t *save_data_list_t::fetch(const void *ptr, save_data_tag_t
 	else
 		gi.Com_PrintFmt("value pointer {} was not linked to save tag {}\n", ptr, (int32_t)tag);
 
-	return nullptr;
+	static save_data_list_t invalid_save_data("<invalid save data>", SAVE_DATA_MMOVE, nullptr, false, false);
+
+	invalid_save_data.tag = tag;
+	invalid_save_data.ptr = ptr;
+
+	return &invalid_save_data;
 }
 
 std::string json_error_stack;

--- a/src/g_save_test.cpp
+++ b/src/g_save_test.cpp
@@ -1,0 +1,89 @@
+#include <cassert>
+#include <cstring>
+
+#include "g_local.h"
+
+// Stub globals required by g_save.cpp
+local_game_import_t gi{};
+g_fmt_data_t g_fmt_data{};
+
+cvar_t strict_stub{
+	const_cast<char *>("g_strict_saves"),
+	const_cast<char *>("0"),
+	nullptr,
+	static_cast<cvar_flags_t>(0),
+	0,
+	0.0f,
+	nullptr,
+	0
+};
+
+cvar_t deathmatch_stub{
+	const_cast<char *>("deathmatch"),
+	const_cast<char *>("0"),
+	nullptr,
+	static_cast<cvar_flags_t>(0),
+	0,
+	0.0f,
+	nullptr,
+	0
+};
+
+cvar_t *g_strict_saves = &strict_stub;
+cvar_t *deathmatch = &deathmatch_stub;
+
+/*
+=============
+StubComPrint
+
+Captures formatted error output for validation.
+=============
+*/
+static void StubComPrint(const char *message) {
+	(void)message;
+}
+
+/*
+=============
+StubComError
+
+Captures fatal errors for validation.
+=============
+*/
+static void StubComError(const char *message) {
+	(void)message;
+}
+
+#include "g_save.cpp"
+
+/*
+=============
+ValidateUnknownTagLookup
+
+Ensures save_data_list_t::fetch returns an invalid sentinel for unknown pointers.
+=============
+*/
+static void ValidateUnknownTagLookup() {
+	strict_stub.integer = 0;
+	deathmatch_stub.integer = 0;
+	gi.Com_Print = &StubComPrint;
+	gi.Com_Error = &StubComError;
+
+	const void *unknown_ptr = reinterpret_cast<const void *>(0x1234);
+	const save_data_list_t *result = save_data_list_t::fetch(unknown_ptr, SAVE_FUNC_THINK);
+
+	assert(result != nullptr);
+	assert(!result->valid);
+	assert(result->ptr == unknown_ptr);
+	assert(result->tag == SAVE_FUNC_THINK);
+}
+
+/*
+=============
+main
+=============
+*/
+int main() {
+	ValidateUnknownTagLookup();
+	return 0;
+}


### PR DESCRIPTION
## Summary
- ensure save_data_list_t carries validity information and fetch returns a sentinel for unknown entries
- clear save_data_t pointers when the backing save data entry is invalid
- add a unit test covering unknown tag lookups in the save registry

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e24fbeab88326995dd1967ab365de)