### PR TITLE
Ensure deathmatch intermission retains scoreboard

### DIFF
--- a/docs/intermission_flow_test.md
+++ b/docs/intermission_flow_test.md
@@ -1,0 +1,17 @@
+# Intermission Flow Test: Scoreboard Persistence
+
+## Objective
+Confirm that deathmatch players remain on the scoreboard view throughout intermission instead of being forced back to other HUD layouts.
+
+## Preconditions
+- Start a multiplayer deathmatch session with at least one human or bot participant.
+- Reach a state where fraglimit or timelimit is close to completion so intermission can be triggered quickly.
+
+## Steps
+1. Play until the match ends naturally (or use an admin command to end the match) to enter intermission.
+2. Observe the client HUD as intermission begins.
+3. Remain idle during the entire intermission countdown without pressing the score key or toggling menus.
+
+## Expected Result
+- The scoreboard remains visible for the entire intermission without reverting to another HUD state.
+- Player input is not required to keep the scoreboard displayed during intermission.

--- a/src/p_hud.cpp
+++ b/src/p_hud.cpp
@@ -26,6 +26,13 @@ static const char *EndMatchVictorString() {
 
 void MultiplayerScoreboard(gentity_t *ent);
 
+/*
+=============
+MoveClientToIntermission
+
+Move a client into the intermission state and set HUD visibility.
+=============
+*/
 void MoveClientToIntermission(gentity_t *ent) {
 	// [Paril-KEX]
 	if (ent->client->ps.pmove.pm_type != PM_FREEZE)
@@ -57,7 +64,9 @@ void MoveClientToIntermission(gentity_t *ent) {
 	ent->client->grenade_time = 0_ms;
 
 	ent->client->showhelp = false;
-	ent->client->showscores = false;
+
+	if (!deathmatch->integer)
+		ent->client->showscores = false;
 
 	globals.server_flags &= ~SERVER_FLAG_SLOW_TIME;
 


### PR DESCRIPTION
## Summary
- keep deathmatch clients in scoreboard view at intermission by avoiding the showscores reset
- document an intermission flow test to confirm the scoreboard stays visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2532c8148326b3b71a55154747fe)