### PR TITLE
Make pain animation cycle per-client

### DIFF
--- a/src/g_local.h
+++ b/src/g_local.h
@@ -3592,6 +3592,7 @@ struct gclient_t {
 	bool			anim_duck;
 	bool			anim_run;
 	gtime_t			anim_time;
+	int32_t			pain_anim_index;
 
 	// powerup timers
 	gtime_t pu_time_quad;

--- a/src/p_view.cpp
+++ b/src/p_view.cpp
@@ -106,15 +106,15 @@ void P_DamageFeedback(gentity_t *player) {
 
 	// start a pain animation if still in the player model
 	if (client->anim_priority < ANIM_PAIN && player->s.modelindex == MODELINDEX_PLAYER) {
-		static int i;
+		int &pain_anim_index = client->pain_anim_index;
 
 		client->anim_priority = ANIM_PAIN;
 		if (client->ps.pmove.pm_flags & PMF_DUCKED) {
 			player->s.frame = FRAME_crpain1 - 1;
 			client->anim_end = FRAME_crpain4;
 		} else {
-			i = (i + 1) % 3;
-			switch (i) {
+			pain_anim_index = (pain_anim_index + 1) % 3;
+			switch (pain_anim_index) {
 			case 0:
 				player->s.frame = FRAME_pain101 - 1;
 				client->anim_end = FRAME_pain104;
@@ -132,7 +132,6 @@ void P_DamageFeedback(gentity_t *player) {
 
 		client->anim_time = 0_ms;
 	}
-
 	realcount = count;
 
 	// if we took health damage, do a minimum clamp


### PR DESCRIPTION
## Summary
- store a per-client pain animation index alongside other animation state
- use the client-specific index when selecting pain animations instead of a shared static

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e25472288832691778891f6686009)