### PR TITLE
Preserve custom gravity during push movement

### DIFF
--- a/docs/custom_gravity_tests.md
+++ b/docs/custom_gravity_tests.md
@@ -1,0 +1,8 @@
+# Custom Gravity Push Coverage
+
+A manual check to ensure custom gravity values survive push interactions:
+
+1. Spawn a movable entity (e.g., a crate) and set its `gravity` to a non-default value such as `0.5`.
+2. Position the entity on top of a moving platform so it will be pushed during the simulation.
+3. Run a push movement tick and confirm the entity's `gravity` remains `0.5` after the push completes.
+4. Verify triggers along the movement path still fire for the pushed entity.

--- a/src/g_phys.cpp
+++ b/src/g_phys.cpp
@@ -189,6 +189,7 @@ Does not change the entities velocity at all
 static trace_t G_PushEntity(gentity_t *ent, const vec3_t &push) {
 	vec3_t start = ent->s.origin;
 	vec3_t end = start + push;
+	float saved_gravity = ent->gravity;
 
 	trace_t trace = gi.trace(start, ent->mins, ent->maxs, end, ent, G_GetClipMask(ent));
 
@@ -207,8 +208,8 @@ static trace_t G_PushEntity(gentity_t *ent, const vec3_t &push) {
 		}
 	}
 
-	// FIXME - is this needed?
-	ent->gravity = 1.0;
+	if (ent->gravity != saved_gravity)
+		ent->gravity = saved_gravity;
 
 	if (ent->inuse)
 		G_TouchTriggers(ent);


### PR DESCRIPTION
## Summary
- preserve incoming gravity values for entities during push movement traces
- add coverage notes for validating custom gravity through push interactions

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2553b3c08326b735a327135cfbc6)