### PR TITLE
Handle null think fallback and add test

### DIFF
--- a/src/g_phys.cpp
+++ b/src/g_phys.cpp
@@ -2,7 +2,7 @@
 // Licensed under the GNU General Public License 2.0.
 // g_phys.c
 
-#include "g_local.h"
+#include "g_runthink.h"
 
 /*
 
@@ -93,19 +93,16 @@ Runs thinking code for this frame if necessary
 =============
 */
 bool G_RunThink(gentity_t *ent) {
-	gtime_t thinktime = ent->nextthink;
-	if (thinktime <= 0_ms)
-		return true;
-	if (thinktime > level.time)
-		return true;
-
-	ent->nextthink = 0_ms;
-	if (!ent->think)
-		//gi.Com_Error("nullptr ent->think");
-		return false;	//true;
-	ent->think(ent);
-
-	return false;
+	return G_RunThinkImpl(
+		ent,
+		level.time,
+		[](gentity_t *warn_ent) {
+			const char *name = warn_ent->classname ? warn_ent->classname : "<unknown>";
+			gi.Com_PrintFmt("G_RunThink: null think function for entity \"{}\"\n", name);
+		},
+		[](gentity_t *warn_ent) {
+			G_FreeEntity(warn_ent);
+		});
 }
 
 /*

--- a/src/g_runthink.h
+++ b/src/g_runthink.h
@@ -1,0 +1,33 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
+
+#pragma once
+
+#include "g_local.h"
+
+/*
+=============
+G_RunThinkImpl
+
+Shared implementation for running entity think functions
+=============
+*/
+template<typename Entity, typename Logger, typename Fallback>
+bool G_RunThinkImpl(Entity *ent, const gtime_t &current_time, Logger &&log_warning, Fallback &&fallback_action) {
+	gtime_t thinktime = ent->nextthink;
+	if (thinktime <= 0_ms)
+		return true;
+	if (thinktime > current_time)
+		return true;
+
+	ent->nextthink = 0_ms;
+	if (!ent->think) {
+		log_warning(ent);
+		fallback_action(ent);
+		return false;
+	}
+
+	ent->think(ent);
+
+	return false;
+}

--- a/src/tests/g_runthink_test.cpp
+++ b/src/tests/g_runthink_test.cpp
@@ -1,0 +1,71 @@
+#include "g_runthink.h"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+struct TestEntity {
+	gtime_t nextthink{};
+	void (*think)(TestEntity *) = nullptr;
+	const char *classname = "test";
+	bool freed = false;
+};
+
+/*
+=============
+DummyThink
+
+Marks that a think function ran for testing
+=============
+*/
+static void DummyThink(TestEntity *ent) {
+	ent->classname = "ran";
+}
+
+/*
+=============
+main
+
+Entry point for G_RunThinkImpl tests
+=============
+*/
+int main() {
+	TestEntity ent{};
+	ent.nextthink = 1_ms;
+
+	bool warning_called = false;
+	std::vector<std::string> messages;
+
+	auto logger = [&](TestEntity *warn_ent) {
+		warning_called = true;
+		messages.emplace_back(warn_ent->classname ? warn_ent->classname : "<unknown>");
+	};
+
+	auto fallback = [&](TestEntity *warn_ent) {
+		warn_ent->freed = true;
+	};
+
+	bool result = G_RunThinkImpl(&ent, 1_ms, logger, fallback);
+
+	assert(!result);
+	assert(warning_called);
+	assert(ent.freed);
+	assert(ent.nextthink == 0_ms);
+	assert(messages.size() == 1);
+	assert(messages.front() == "test");
+
+	ent.think = DummyThink;
+	ent.freed = false;
+	ent.nextthink = 1_ms;
+	warning_called = false;
+	messages.clear();
+
+	result = G_RunThinkImpl(&ent, 1_ms, logger, fallback);
+
+	assert(!result);
+	assert(!warning_called);
+	assert(!ent.freed);
+	assert(ent.classname == std::string("ran"));
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add shared think runner helper that logs null think callbacks and frees the entity deterministically
- update G_RunThink to use the helper and warn when think is missing
- add a unit test covering the warning path and a valid think call

## Testing
- g++ -std=c++20 -Isrc src/tests/g_runthink_test.cpp -o /tmp/g_runthink_test
- /tmp/g_runthink_test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2564942c8326b863830a74b9ee35)