### PR TITLE
Validate ground entity traces

### DIFF
--- a/docs/regression_tests.md
+++ b/docs/regression_tests.md
@@ -1,0 +1,12 @@
+# Regression Tests
+
+## Mover collision resolution
+- **Purpose:** Prevent movers from disappearing when collision traces reference freed or invalid entities during ground detection.
+- **Setup:**
+  - Create a simple map with a platform mover intersecting with another entity that can be removed mid-move.
+  - Instrument the mover so that a collision resolution pass occurs immediately after the other entity is freed.
+- **Steps:**
+  1. Trigger the mover so it begins translating through the space occupied by the soon-to-be-removed entity.
+  2. Remove the obstructing entity during the mover's travel to force a collision trace against an invalid reference.
+  3. Allow the mover to complete its motion.
+- **Expected result:** The mover finishes its path without being unlinked or lost from the world after the collision trace references an invalid entity.

--- a/src/g_phys.cpp
+++ b/src/g_phys.cpp
@@ -134,6 +134,7 @@ The basic solid body movement clip that slides along multiple planes
 */
 void G_FlyMove(gentity_t *ent, float time, contents_t mask) {
 	ent->groundentity = nullptr;
+	ent->groundentity_linkcount = 0;
 
 	touch_list_t touch;
 	PM_StepSlideMove_Generic(ent->s.origin, ent->velocity, time, ent->mins, ent->maxs, touch, false, [&](const vec3_t &start, const vec3_t &mins, const vec3_t &maxs, const vec3_t &end) {
@@ -144,8 +145,13 @@ void G_FlyMove(gentity_t *ent, float time, contents_t mask) {
 		auto &trace = touch.traces[i];
 
 		if (trace.plane.normal[2] > 0.7f) {
-			ent->groundentity = trace.ent;
-			ent->groundentity_linkcount = trace.ent->linkcount;
+			if (trace.ent && trace.ent->inuse) {
+				ent->groundentity = trace.ent;
+				ent->groundentity_linkcount = trace.ent->linkcount;
+			} else {
+				ent->groundentity = nullptr;
+				ent->groundentity_linkcount = 0;
+			}
 		}
 
 		//


### PR DESCRIPTION
## Summary
- guard groundentity assignment in G_FlyMove against null or unused traces
- reset ground link data when a collision trace yields an invalid entity
- document regression steps to cover movers disappearing during collision resolution

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2567aed8832693304a732f2205a4)