### PR TITLE
Add configurable limit for doppelganger pickups

### DIFF
--- a/src/g_items.cpp
+++ b/src/g_items.cpp
@@ -1812,6 +1812,13 @@ static bool Pickup_Nuke(gentity_t *ent, gentity_t *other) {
 
 //======================================================================
 
+/*
+=============
+Use_Doppelganger
+
+Spawns and launches a doppelganger from the player's position.
+=============
+*/
 static void Use_Doppelganger(gentity_t *ent, gitem_t *item) {
 	vec3_t forward, right;
 	vec3_t createPt, spawnPt;
@@ -1835,15 +1842,34 @@ static void Use_Doppelganger(gentity_t *ent, gitem_t *item) {
 	fire_doppelganger(ent, spawnPt, forward);
 }
 
+/*
+=============
+Pickup_Doppelganger
+
+Attempts to pick up a doppelganger while respecting the configured limit.
+=============
+*/
 static bool Pickup_Doppelganger(gentity_t *ent, gentity_t *other) {
 	int quantity;
+	int max_doppelgangers;
 
 	if (!deathmatch->integer)
 		return false;
 
-	quantity = other->client->pers.inventory[ent->item->id];
-	if (quantity >= 1) // FIXME - apply max to doppelgangers
+	max_doppelgangers = g_doppelganger_max->integer;
+	if (max_doppelgangers < 0)
+		max_doppelgangers = 0;
+
+	if (!max_doppelgangers) {
+		gi.LocClient_Print(other, PRINT_HIGH, "Doppelganger pickups are disabled.");
 		return false;
+	}
+
+	quantity = other->client->pers.inventory[ent->item->id];
+	if (quantity >= max_doppelgangers) {
+		gi.LocClient_Print(other, PRINT_HIGH, "You can only carry {} doppelgangers.", max_doppelgangers);
+		return false;
+	}
 
 	other->client->pers.inventory[ent->item->id]++;
 

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -2420,6 +2420,7 @@ extern cvar_t *g_dm_spawnpads;
 extern cvar_t *g_dm_strong_mines;
 extern cvar_t *g_dm_timeout_length;
 extern cvar_t *g_dm_weapons_stay;
+extern cvar_t *g_doppelganger_max;
 extern cvar_t *g_drop_cmds;
 extern cvar_t *g_entity_override_dir;
 extern cvar_t *g_entity_override_load;

--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -138,6 +138,7 @@ cvar_t *g_dm_strong_mines;
 cvar_t *g_dm_timeout_length;
 cvar_t *g_dm_weapons_stay;
 cvar_t *g_drop_cmds;
+cvar_t *g_doppelganger_max;
 cvar_t *g_entity_override_dir;
 cvar_t *g_entity_override_load;
 cvar_t *g_entity_override_save;
@@ -869,6 +870,7 @@ static void InitGame() {
 	g_huntercam = gi.cvar("g_huntercam", "1", CVAR_SERVERINFO | CVAR_LATCH);
 	g_dm_strong_mines = gi.cvar("g_dm_strong_mines", "0", CVAR_NOFLAGS);
 	g_dm_random_items = gi.cvar("g_dm_random_items", "0", CVAR_NOFLAGS);
+	g_doppelganger_max = gi.cvar("g_doppelganger_max", "1", CVAR_NOFLAGS);
 
 	// game modifications
 	g_instagib = gi.cvar("g_instagib", "0", CVAR_SERVERINFO | CVAR_LATCH);


### PR DESCRIPTION
## Summary
- add a `g_doppelganger_max` cvar to configure how many doppelgangers a player can carry
- enforce the configured cap in `Pickup_Doppelganger`, including messaging when pickups are disabled or the limit is reached

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2591f7a8832699395cdf52036527)