### PR TITLE
Guard BroadcastFriendlyMessage when message is missing

### DIFF
--- a/src/g_utils.cpp
+++ b/src/g_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "g_activation.h"
 #include "g_local.h"
+#include "g_utils_friendly_message.h"
 #include <cerrno>
 #include <vector>
 #include "g_utils_target_selection.h"
@@ -153,6 +154,9 @@ active players.
 =============
 */
 void BroadcastFriendlyMessage(team_t team, const char *msg) {
+	if (!FriendlyMessageHasText(msg))
+		return;
+
 	for (auto ce : active_clients()) {
 		const bool playing = ClientIsPlaying(ce->client);
 		if (!playing) {

--- a/src/g_utils_friendly_message.h
+++ b/src/g_utils_friendly_message.h
@@ -1,0 +1,13 @@
+/*
+=============
+FriendlyMessageHasText
+
+Determines if the provided message pointer is non-null and non-empty.
+=============
+*/
+#pragma once
+
+inline bool FriendlyMessageHasText(const char *msg)
+{
+	return msg && *msg;
+}

--- a/tests/friendly_message_tests.cpp
+++ b/tests/friendly_message_tests.cpp
@@ -1,0 +1,18 @@
+#include "../src/g_utils_friendly_message.h"
+#include <cassert>
+
+/*
+=============
+main
+
+Regression coverage for friendly message validation.
+=============
+*/
+int main()
+{
+	assert(!FriendlyMessageHasText(nullptr));
+	assert(!FriendlyMessageHasText(""));
+	assert(FriendlyMessageHasText("hello"));
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add a helper to validate friendly broadcast text and reuse it in BroadcastFriendlyMessage
- skip broadcasting when the message is null or empty to avoid unsafe formatting
- add regression coverage for null, empty, and valid friendly messages

## Testing
- g++ -Isrc tests/friendly_message_tests.cpp -o friendly_message_tests
- ./friendly_message_tests
- g++ -Isrc tests/activation_message_tests.cpp src/g_activation.cpp -o activation_message_tests
- ./activation_message_tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2796fc3c8326bbd42f2be4088e96)