### PR TITLE
Add configurable doppelganger pickup limit

### DIFF
--- a/src/g_items.cpp
+++ b/src/g_items.cpp
@@ -1857,10 +1857,10 @@ static bool Pickup_Doppelganger(gentity_t *ent, gentity_t *other) {
 	if (!deathmatch->integer)
 		return false;
 
-	max_allowed = G_GetHoldableMax(g_dm_holdable_doppel_max->integer, ent->item->quantity_warn, 1);
+	max_allowed = G_GetHoldableMax(g_dm_holdable_doppel_max->integer, ent->item->quantity_max, 1);
 	quantity = other->client->pers.inventory[ent->item->id];
 	if (quantity >= max_allowed) {
-		gi.cprintf(other, PRINT_LOW, "You can't carry more %s\n", ent->item->pickup_name);
+		gi.cprintf(other, PRINT_LOW, "You can only carry %d %s\n", max_allowed, ent->item->pickup_name);
 		return false;
 	}
 
@@ -5078,7 +5078,8 @@ model="models/items/dopple/tris.md2"
 /* tag */ POWERUP_DOPPELGANGER,
 /* precaches */ "models/objects/dopplebase/tris.md2 models/items/spawngro3/tris.md2 medic_commander/monsterspawn1.wav models/items/hunter/tris.md2 models/items/vengnce/tris.md2",
 /* sort_id */ 0,
-/* quantity_warn */ 1
+/* quantity_warn */ 1,
+/* quantity_max */ 1
 },
 
 /* Tag Token */

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -1303,6 +1303,7 @@ struct gitem_t {
 
 	int32_t			sort_id = 0; // used by some items to control their sorting
 	int32_t			quantity_warn = 5; // when to warn on low ammo
+	int32_t			quantity_max = 0; // maximum quantity a holdable can stack to (0 = use fallback)
 
 	// set in InitItems, don't set by hand
 	// circular list of chained weapons


### PR DESCRIPTION
## Summary
- add an item max field to configure holdable stack limits
- enforce the configurable doppelganger pickup cap with clearer denial messaging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2aed9f088326bf2e79e4ad9a6baf)