### PR TITLE
Handle save data duplicate message formatting

### DIFF
--- a/src/g_save.cpp
+++ b/src/g_save.cpp
@@ -93,10 +93,12 @@ void InitSave() {
 			const save_data_list_t *existing = existing_name->second;
 
 			if (!deathmatch->integer) {
+				const void *existing_ptr = reinterpret_cast<const void *>(existing);
+
 				if (g_strict_saves->integer)
-					gi.Com_ErrorFmt("duplicate save type name {} (tag {}) already linked to pointer {}, cannot add pointer {}", link->name, (int32_t)link->tag, existing, link_ptr);
+					gi.Com_ErrorFmt("duplicate save type name {} (tag {}) already linked to pointer {}, cannot add pointer {}", link->name, (int32_t)link->tag, existing_ptr, link_ptr);
 				else
-					gi.Com_PrintFmt("duplicate save type name {} (tag {}) already linked to pointer {}, cannot add pointer {}", link->name, (int32_t)link->tag, existing, link_ptr);
+					gi.Com_PrintFmt("duplicate save type name {} (tag {}) already linked to pointer {}, cannot add pointer {}", link->name, (int32_t)link->tag, existing_ptr, link_ptr);
 			}
 
 			continue;


### PR DESCRIPTION
## Summary
- cast duplicate save data pointers to void* before formatting to satisfy fmt compile-time checks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eeda9af548328b26ce8825f42687f)