### PR TITLE
Handle empty target selection choices

### DIFF
--- a/src/g_utils_target_selection.h
+++ b/src/g_utils_target_selection.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdio>
 #include <utility>
 #include <vector>
 
@@ -16,6 +17,11 @@ Selects a random target from a list using the provided random generator.
 */
 template<typename T, typename RandomFunc>
 T *G_SelectRandomTarget(const std::vector<T *> &choices, RandomFunc &&random_func) {
+	if (choices.empty()) {
+		std::fprintf(stderr, "%s: attempted random selection with no available targets.\n", __FUNCTION__);
+		return nullptr;
+	}
+
 	assert(!choices.empty());
 	return choices[std::forward<RandomFunc>(random_func)(choices.size())];
 }

--- a/src/tests/g_utils_target_selection_test.cpp
+++ b/src/tests/g_utils_target_selection_test.cpp
@@ -35,5 +35,8 @@ int main() {
 	}
 
 	assert(saw_ninth_entry);
+
+	std::vector<DummyTarget *> empty_choices;
+	assert(G_SelectRandomTarget(empty_choices, cycling_random) == nullptr);
 	return 0;
 }


### PR DESCRIPTION
## Summary
- add a runtime guard in G_SelectRandomTarget to warn and return nullptr when no choices are available
- extend the target selection test to cover empty choice handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa2cdbbe883289576d662b6bd2b8c)