### PR TITLE
Define save data constructor and add HUD victor build

### DIFF
--- a/src/g_save.cpp
+++ b/src/g_save.cpp
@@ -113,6 +113,14 @@ void InitSave() {
 }
 // initializer for save data
 /*
+=============
+save_data_list_t::save_data_list_t
+
+Registers a save data entry and optionally links it into the global list used for lookups.
+=============
+*/
+save_data_list_t::save_data_list_t(const char *name_in, save_data_tag_t tag_in, const void *ptr_in, bool link, bool valid_in) :
+	name(name_in),
 	tag(tag_in),
 	ptr(ptr_in),
 	next(nullptr),

--- a/src/game.vcxproj
+++ b/src/game.vcxproj
@@ -144,6 +144,7 @@
     <ClInclude Include="monsters\m_turret.h" />
     <ClInclude Include="monsters\m_widow.h" />
     <ClInclude Include="monsters\m_widow2.h" />
+    <ClInclude Include="p_hud_victor.h" />
     <ClInclude Include="p_menu.h" />
     <ClInclude Include="q_std.h" />
     <ClInclude Include="q_vec3.h" />
@@ -214,6 +215,7 @@
     <ClCompile Include="monsters\m_widow2.cpp" />
     <ClCompile Include="p_client.cpp" />
     <ClCompile Include="p_hud.cpp" />
+    <ClCompile Include="p_hud_victor.cpp" />
     <ClCompile Include="p_menu.cpp" />
     <ClCompile Include="p_move.cpp" />
     <ClCompile Include="p_trail.cpp" />

--- a/src/game.vcxproj.filters
+++ b/src/game.vcxproj.filters
@@ -126,6 +126,7 @@
     <ClInclude Include="monsters\m_widow2.h">
       <Filter>monsters</Filter>
     </ClInclude>
+    <ClInclude Include="p_hud_victor.h" />
     <ClInclude Include="p_menu.h" />
   </ItemGroup>
   <ItemGroup>
@@ -152,6 +153,7 @@
     <ClCompile Include="g_weapon.cpp" />
     <ClCompile Include="p_client.cpp" />
     <ClCompile Include="p_hud.cpp" />
+    <ClCompile Include="p_hud_victor.cpp" />
     <ClCompile Include="p_move.cpp" />
     <ClCompile Include="p_trail.cpp" />
     <ClCompile Include="p_view.cpp" />


### PR DESCRIPTION
## Summary
- implement the missing save_data_list_t constructor so save data entries link correctly
- include the HUD victor header/source in the Visual Studio project files to resolve unresolved symbol

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69204e6577688328a64cdc64c882a523)