### PR TITLE
Clamp random target selection index

### DIFF
--- a/src/g_utils_target_selection.h
+++ b/src/g_utils_target_selection.h
@@ -5,6 +5,7 @@
 
 #include <cassert>
 #include <cstdio>
+#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -23,6 +24,10 @@ T *G_SelectRandomTarget(const std::vector<T *> &choices, RandomFunc &&random_fun
 	}
 
 	assert(!choices.empty());
-	return choices[std::forward<RandomFunc>(random_func)(choices.size())];
+
+	const std::size_t max_index = choices.size() - 1;
+	const std::size_t generated_index = std::forward<RandomFunc>(random_func)(max_index);
+	const std::size_t clamped_index = generated_index > max_index ? max_index : generated_index;
+	return choices[clamped_index];
 }
 


### PR DESCRIPTION
## Summary
- clamp randomly generated target index before indexing the choices vector
- update random callback usage to avoid inclusive upper-bound results
- include <cstddef> for std::size_t usage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ed1bde088328a0739f53249c81b1)