### PR TITLE
Add client guard to CopyToBodyQue

### DIFF
--- a/src/p_client.cpp
+++ b/src/p_client.cpp
@@ -2355,7 +2355,20 @@ static THINK(BodySink) (gentity_t* ent) -> void {
 	gi.linkentity(ent);
 }
 
+
+/*
+=============
+CopyToBodyQue
+
+Copy the entity state into a body queue slot for later corpse handling.
+=============
+*/
 void CopyToBodyQue(gentity_t* ent) {
+	if (!ent->client) {
+		gi.unlinkentity(ent);
+		return;
+	}
+
 	// if we were completely removed, don't bother with a body
 	if (!ent->s.modelindex)
 		return;


### PR DESCRIPTION
## Summary
- add function header comment and null-client guard to CopyToBodyQue
- prevent accessing client fields for entities without clients to avoid unsafe corpse handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ed187e0083289f6bd9d8edc67a14)