### PR TITLE
Respect ground spawn height limit

### DIFF
--- a/src/g_monster_spawn.cpp
+++ b/src/g_monster_spawn.cpp
@@ -185,6 +185,16 @@ bool CheckGroundSpawnPoint(const vec3_t &origin, const vec3_t &entMins, const ve
 	if (!CheckSpawnPoint(origin, entMins, entMaxs, gravityVector))
 		return false;
 
+	vec3_t gravity_dir = gravityVector.normalized();
+
+	if (!gravity_dir)
+		gravity_dir = { 0.0f, 0.0f, -1.0f };
+
+	trace_t trace = gi.trace(origin, entMins, entMaxs, origin + (gravity_dir * height), nullptr, MASK_MONSTERSOLID);
+
+	if (trace.fraction == 1.0f)
+		return false;
+
 	if (M_CheckBottom_Fast_Generic(origin + entMins, origin + entMaxs, gravityVector))
 		return true;
 


### PR DESCRIPTION
## Summary
- trace toward the ground using the height allowance when validating spawn points
- add a test case that fails when no surface is found within the allowed height

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ed12154c8328b7c205ddcfdada28)