### PR TITLE
Add client null check when closing menu

### DIFF
--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -71,8 +71,18 @@ menu_hnd_t *P_Menu_Open(gentity_t *ent, const menu_t *entries, int cur, int num,
 	return hnd;
 }
 
+/*
+=============
+P_Menu_Close
+
+Closes the active menu for the entity and frees associated resources.
+=============
+*/
 void P_Menu_Close(gentity_t *ent) {
 	menu_hnd_t *hnd;
+
+	if (!ent->client)
+		return;
 
 	if (!ent->client->menu)
 		return;
@@ -84,7 +94,7 @@ void P_Menu_Close(gentity_t *ent) {
 	gi.TagFree(hnd);
 	ent->client->menu = nullptr;
 	ent->client->showscores = false;
-	
+
 	gentity_t *e = ent->client->follow_target ? ent->client->follow_target : ent;
 	ent->client->ps.stats[STAT_SHOW_STATUSBAR] = !ClientIsPlaying(e->client) ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- add an early null check for `ent->client` in `P_Menu_Close`
- ensure the menu close routine no-ops when the client reference is missing
- document the function behavior with a header comment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ed1020cc83288059ce55e9c34e0a)