### PR TITLE
Fix menu text copy bounds and add coverage

### DIFF
--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 #include "g_local.h"
+#include <cassert>
 
 /*
 ============
@@ -15,10 +16,13 @@ void P_Menu_Dirty() {
 		}
 }
 
-// Note that the pmenu entries are duplicated
-// this is so that a static set of pmenu entries can be used
-// for multiple clients and changed without interference
-// note that arg will be freed when the menu is closed, it must be allocated memory
+/*
+=============
+P_Menu_Open
+
+Open a menu for a client and duplicate entry data for safe modification.
+=============
+*/
 menu_hnd_t *P_Menu_Open(gentity_t *ent, const menu_t *entries, int cur, int num, void *arg, UpdateFunc_t UpdateFunc) {
 	menu_hnd_t		*hnd;
 	const menu_t	*p;
@@ -40,8 +44,9 @@ menu_hnd_t *P_Menu_Open(gentity_t *ent, const menu_t *entries, int cur, int num,
 	hnd->entries = (menu_t *)gi.TagMalloc(sizeof(menu_t) * num, TAG_LEVEL);
 	memcpy(hnd->entries, entries, sizeof(menu_t) * num);
 	// duplicate the strings since they may be from static memory
-	for (i = 0; i < num; i++)
-		Q_strlcpy(hnd->entries[i].text, entries[i].text, sizeof(entries[i].text));
+	for (i = 0; i < num; i++) {
+		assert(Q_strlcpy(hnd->entries[i].text, entries[i].text, sizeof(hnd->entries[i].text)) < sizeof(hnd->entries[i].text));
+	}
 
 	hnd->num = num;
 

--- a/tests/menu_copy_tests.cpp
+++ b/tests/menu_copy_tests.cpp
@@ -1,0 +1,31 @@
+#include "../src/q_std.h"
+#include <cassert>
+#include <cstring>
+
+/*
+=============
+main
+
+Verify Q_strlcpy copies menu-sized buffers without truncation when the destination size is provided.
+=============
+*/
+int main()
+{
+	char destination[256] = {};
+	const char short_source[] = "Short label";
+	const size_t copied = Q_strlcpy(destination, short_source, sizeof(destination));
+
+	assert(copied == strlen(short_source));
+	assert(strcmp(destination, short_source) == 0);
+
+	char long_source[300];
+	memset(long_source, 'a', sizeof(long_source));
+	long_source[sizeof(long_source) - 1] = '\0';
+
+	char truncated[16] = {};
+	const size_t truncated_length = Q_strlcpy(truncated, long_source, sizeof(truncated));
+	assert(truncated_length >= sizeof(truncated));
+	assert(truncated[sizeof(truncated) - 1] == '\0');
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- ensure menu entry text duplication uses the destination buffer size
- guard against truncated menu text with assertions
- add a regression test covering Q_strlcpy behavior for menu-sized buffers

## Testing
- ❌ `g++ -std=c++17 tests/menu_copy_tests.cpp src/q_std.cpp -I src -o /tmp/menu_copy_tests` (linker errors due to unresolved engine globals)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ed0e85cc8328aebaaa2bb69a9963)