### PR TITLE
Initialize activation message plan

### DIFF
--- a/src/g_activation.cpp
+++ b/src/g_activation.cpp
@@ -9,7 +9,7 @@ Creates an activation message plan for the provided context.
 */
 activation_message_plan_t BuildActivationMessagePlan(bool has_message, bool has_activator, bool activator_is_monster, bool coop_global, bool coop_enabled, int noise_index)
 {
-	activation_message_plan_t plan;
+	activation_message_plan_t plan{};
 
 	if (!has_message)
 		return plan;


### PR DESCRIPTION
## Summary
- initialize the activation message plan with value initialization to ensure defined defaults on early returns

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218d25b3a48328bde33b9b92cf3628)