### PR TITLE
Handle failed monster spawns in ground creation tests

### DIFF
--- a/src/g_monster_spawn.cpp
+++ b/src/g_monster_spawn.cpp
@@ -43,9 +43,20 @@ gentity_t *CreateMonster(const vec3_t &origin, const vec3_t &angles, const char 
 	newEnt->gravityVector = { 0, 0, -1 };
 	ED_CallSpawn(newEnt);
 	newEnt->s.renderfx |= RF_IR_VISIBLE;
-	
+
 	return newEnt;
 }
+
+#else
+/*
+=============
+CreateMonster
+
+Provided by unit tests when MONSTER_SPAWN_TESTS is defined.
+=============
+*/
+gentity_t *CreateMonster(const vec3_t &origin, const vec3_t &angles, const char *classname);
+#endif
 
 /*
 =============


### PR DESCRIPTION
## Summary
- allow unit tests to supply their own CreateMonster implementation under MONSTER_SPAWN_TESTS
- add stubs and a new test to validate CreateGroundMonster returns nullptr when monster creation fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218d26cc4083289bc0380f9ece66a3)