### PR TITLE
Improve friendly message validation

### DIFF
--- a/src/g_utils_friendly_message.h
+++ b/src/g_utils_friendly_message.h
@@ -2,12 +2,14 @@
 =============
 FriendlyMessageHasText
 
-Determines if the provided message pointer is non-null and non-empty.
+Determines if the provided message pointer is non-null, non-empty, and
+contains a terminator within a limited scan.
 =============
 */
 #pragma once
+#include <cstring>
 
 inline bool FriendlyMessageHasText(const char *msg)
 {
-	return msg && *msg;
+	return msg && *msg && strnlen(msg, 256) < 256;
 }

--- a/tests/friendly_message_tests.cpp
+++ b/tests/friendly_message_tests.cpp
@@ -1,5 +1,6 @@
 #include "../src/g_utils_friendly_message.h"
 #include <cassert>
+#include <algorithm>
 
 /*
 =============
@@ -9,10 +10,19 @@ Regression coverage for friendly message validation.
 =============
 */
 int main()
-{
+	{
 	assert(!FriendlyMessageHasText(nullptr));
 	assert(!FriendlyMessageHasText(""));
 	assert(FriendlyMessageHasText("hello"));
+
+	char unterminated[256];
+	std::fill_n(unterminated, 256, 'a');
+	assert(!FriendlyMessageHasText(unterminated));
+
+	char bounded[256];
+	std::fill_n(bounded, 255, 'b');
+	bounded[255] = '\0';
+	assert(FriendlyMessageHasText(bounded));
 
 	return 0;
 }


### PR DESCRIPTION
## Summary
- ensure FriendlyMessageHasText checks for an inline terminator within a bounded scan
- add test coverage for unterminated and properly terminated messages within the bound

## Testing
- g++ -std=c++17 tests/friendly_message_tests.cpp -o /tmp/friendly_message_tests && /tmp/friendly_message_tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218d30098c83289427171191721429)