### PR TITLE
Handle invalid random target indices

### DIFF
--- a/src/g_utils_target_selection.h
+++ b/src/g_utils_target_selection.h
@@ -27,7 +27,12 @@ T *G_SelectRandomTarget(const std::vector<T *> &choices, RandomFunc &&random_fun
 
 	const std::size_t max_index = choices.size() - 1;
 	const std::size_t generated_index = std::forward<RandomFunc>(random_func)(max_index);
-	const std::size_t clamped_index = generated_index > max_index ? max_index : generated_index;
-	return choices[clamped_index];
-}
+
+	if (generated_index > max_index) {
+		std::fprintf(stderr, "%s: generated index %zu exceeds max index %zu.\n", __FUNCTION__, generated_index, max_index);
+		return nullptr;
+	}
+
+	return choices[generated_index];
+	}
 

--- a/src/tests/g_utils_target_selection_test.cpp
+++ b/src/tests/g_utils_target_selection_test.cpp
@@ -5,13 +5,13 @@
 #include "../g_utils_target_selection.h"
 
 struct DummyTarget {
-};
+	};
 
 /*
 =============
 main
 
-Validates that the target selection helper can pick entries beyond the first eight options.
+Validates that the target selection helper can pick entries beyond the first eight options and rejects invalid random indices.
 =============
 */
 int main() {
@@ -23,7 +23,7 @@ int main() {
 		references.push_back(&target);
 
 	auto cycling_random = [index = static_cast<int32_t>(0)](size_t max) mutable {
-		return (index++) % static_cast<int32_t>(max);
+		return (index++) % static_cast<int32_t>(max + 1);
 	};
 
 	bool saw_ninth_entry = false;
@@ -38,5 +38,11 @@ int main() {
 
 	std::vector<DummyTarget *> empty_choices;
 	assert(G_SelectRandomTarget(empty_choices, cycling_random) == nullptr);
+
+	auto bad_random = [](size_t) {
+		return static_cast<size_t>(100);
+	};
+
+	assert(G_SelectRandomTarget(references, bad_random) == nullptr);
 	return 0;
 }


### PR DESCRIPTION
## Summary
- add bounds checking to `G_SelectRandomTarget` to log and reject invalid random indices
- update target selection test to cover invalid RNG results while ensuring highest index can be chosen

## Testing
- g++ -std=c++17 src/tests/g_utils_target_selection_test.cpp -o /tmp/g_utils_target_selection_test && /tmp/g_utils_target_selection_test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218d32776483288662b737de776b68)