### PR TITLE
Handle failed fly monster spawns

### DIFF
--- a/src/g_monster_spawn.cpp
+++ b/src/g_monster_spawn.cpp
@@ -70,7 +70,12 @@ gentity_t *CreateFlyMonster(const vec3_t &origin, const vec3_t &angles, const ve
 	if (!CheckSpawnPoint(origin, mins, maxs, { 0.0f, 0.0f, -1.0f }))
 		return nullptr;
 
-	return (CreateMonster(origin, angles, classname));
+	gentity_t *newEnt = CreateMonster(origin, angles, classname);
+
+	if (!newEnt)
+		return nullptr;
+
+	return newEnt;
 }
 
 /*

--- a/tests/spawn_gravity_tests.cpp
+++ b/tests/spawn_gravity_tests.cpp
@@ -325,6 +325,31 @@ static void TestGroundSpawnHonorsHeight()
 
 /*
 =============
+TestCreateFlyMonsterReturnsNullOnFailedSpawn
+
+Ensures CreateFlyMonster returns nullptr when CreateMonster fails.
+=============
+*/
+static void TestCreateFlyMonsterReturnsNullOnFailedSpawn()
+{
+	gi.trace = TestTrace;
+	gi.pointcontents = TestPointContents;
+	g_create_monster_should_fail = true;
+
+	vec3_t origin{ 12.0f, -4.0f, 20.0f };
+	vec3_t angles{ 0.0f, 45.0f, 0.0f };
+	vec3_t mins{ -4.0f, -4.0f, -4.0f };
+	vec3_t maxs{ 4.0f, 4.0f, 4.0f };
+
+	gentity_t *spawned = CreateFlyMonster(origin, angles, mins, maxs, "monster_flyer");
+
+	assert(spawned == nullptr);
+
+	g_create_monster_should_fail = false;
+}
+
+/*
+=============
 TestCreateGroundMonsterReturnsNullOnFailedSpawn
 
 Ensures CreateGroundMonster returns nullptr when CreateMonster fails.
@@ -359,6 +384,7 @@ int main()
 	TestNegativeGravityProjectsSpawnVolume();
 	TestGroundChecksUseGravityVector();
 	TestGroundSpawnHonorsHeight();
+	TestCreateFlyMonsterReturnsNullOnFailedSpawn();
 	TestCreateGroundMonsterReturnsNullOnFailedSpawn();
 	return 0;
 }


### PR DESCRIPTION
## Summary
- check CreateMonster result inside CreateFlyMonster and propagate nullptr on failure
- add regression coverage for fly monster creation failures

## Testing
- g++ -std=c++17 tests/spawn_gravity_tests.cpp -o /tmp/spawn_tests *(fails: missing dependency fmt/format.h)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218faaddfc8328894306da10cbe1f8)