### PR TITLE
Ensure menu layout concatenations are bounded

### DIFF
--- a/src/p_menu.h
+++ b/src/p_menu.h
@@ -1,6 +1,8 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
+#include <cstddef>
+
 enum {
 	MENU_ALIGN_LEFT,
 	MENU_ALIGN_CENTER,
@@ -8,34 +10,36 @@ enum {
 };
 
 struct menu_t;
+struct gentity_t;
 
 using UpdateFunc_t = void (*)(gentity_t *ent);
 
 struct menu_hnd_t {
 	menu_t	*entries;
-	int		cur;
-	int		num;
-	void	*arg;
+	int			cur;
+	int			num;
+	void		*arg;
 	UpdateFunc_t UpdateFunc;
 };
 
 using SelectFunc_t = void (*)(gentity_t *ent, menu_hnd_t *hnd);
 
 struct menu_t {
-	char		 text[256];	// 26];	// [64];
-	int			 align;
+	char		 text[256];	// 26]; // [64];
+	int			align;
 	SelectFunc_t SelectFunc;
-	char         text_arg1[64];
+	char	 text_arg1[64];
 };
 
-void		P_Menu_Dirty();
-menu_hnd_t	*P_Menu_Open(gentity_t *ent, const menu_t *entries, int cur, int num, void *arg, UpdateFunc_t UpdateFunc);
-void		P_Menu_Close(gentity_t *ent);
-void		P_Menu_UpdateEntry(menu_t *entry, const char *text, int align, SelectFunc_t SelectFunc);
-void		P_Menu_Do_Update(gentity_t *ent);
-void		P_Menu_Update(gentity_t *ent);
-void		P_Menu_Next(gentity_t *ent);
-void		P_Menu_Prev(gentity_t *ent);
-void		P_Menu_Select(gentity_t *ent);
-void            P_Menu_OpenBanned(gentity_t *ent);
-bool            P_Menu_IsBannedMenu(const menu_hnd_t *hnd);
+bool			 P_Menu_BuildLayoutString(const menu_hnd_t *hnd, char *statusbar, size_t statusbar_size);
+void			 P_Menu_Dirty();
+menu_hnd_t		*P_Menu_Open(gentity_t *ent, const menu_t *entries, int cur, int num, void *arg, UpdateFunc_t UpdateFunc);
+void			 P_Menu_Close(gentity_t *ent);
+void			 P_Menu_UpdateEntry(menu_t *entry, const char *text, int align, SelectFunc_t SelectFunc);
+void			 P_Menu_Do_Update(gentity_t *ent);
+void			 P_Menu_Update(gentity_t *ent);
+void			 P_Menu_Next(gentity_t *ent);
+void			 P_Menu_Prev(gentity_t *ent);
+void			 P_Menu_Select(gentity_t *ent);
+void			 P_Menu_OpenBanned(gentity_t *ent);
+bool			 P_Menu_IsBannedMenu(const menu_hnd_t *hnd);

--- a/tests/menu_layout_truncation_tests.cpp
+++ b/tests/menu_layout_truncation_tests.cpp
@@ -1,0 +1,58 @@
+#include "../src/game.h"
+#include "../src/p_menu.h"
+#include "../src/q_std.h"
+#include <cassert>
+#include <cstring>
+
+/*
+=============
+main
+
+Validate that long menu entries are safely truncated when constructing status bar layouts.
+=============
+*/
+int main()
+{
+	menu_t entries[6] = {};
+
+	for (auto &entry : entries) {
+		memset(entry.text, 'x', sizeof(entry.text) - 1);
+		entry.text[sizeof(entry.text) - 1] = '\0';
+	}
+
+	menu_hnd_t handle{};
+	handle.entries = entries;
+	handle.num = sizeof(entries) / sizeof(entries[0]);
+	handle.cur = 0;
+
+	char small_buffer[64];
+	bool truncated_small = P_Menu_BuildLayoutString(&handle, small_buffer, sizeof(small_buffer));
+
+	assert(truncated_small);
+	assert(small_buffer[sizeof(small_buffer) - 1] == '\0');
+	assert(strlen(small_buffer) < sizeof(small_buffer));
+
+	char large_buffer[MAX_STRING_CHARS];
+	memset(large_buffer, 0, sizeof(large_buffer));
+	bool truncated_large = P_Menu_BuildLayoutString(&handle, large_buffer, sizeof(large_buffer));
+
+	assert(truncated_large);
+	assert(large_buffer[sizeof(large_buffer) - 1] == '\0');
+	assert(strlen(large_buffer) < sizeof(large_buffer));
+
+	menu_t short_entry{};
+	Q_strlcpy(short_entry.text, "Short entry", sizeof(short_entry.text));
+
+	menu_hnd_t short_handle{};
+	short_handle.entries = &short_entry;
+	short_handle.num = 1;
+	short_handle.cur = 0;
+
+	char comfy_buffer[128] = {};
+	bool truncated_short = P_Menu_BuildLayoutString(&short_handle, comfy_buffer, sizeof(comfy_buffer));
+
+	assert(!truncated_short);
+	assert(strlen(comfy_buffer) < sizeof(comfy_buffer));
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- replace raw string concatenation in menu layout generation with a bounded helper
- update menu updates to use the bounded layout builder and warn when truncation occurs
- add tests covering long menu entries to ensure status bar layout strings truncate safely

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218d2d0ee483289b45d336823908be)