### PR TITLE
Fix vec3 abs constexpr

### DIFF
--- a/src/q_vec3.h
+++ b/src/q_vec3.h
@@ -4,6 +4,7 @@
 #pragma once
 
 // q_vec3 - vec3 stuff
+#include <cmath>
 #include <stdexcept>
 #include <type_traits>
 
@@ -20,7 +21,7 @@ struct vec3_t
 	Returns a vector containing the absolute value of each component.
 	=============
 	*/
-	[[nodiscard]] constexpr vec3_t abs() const
+	[[nodiscard]] inline vec3_t abs() const
 	{
 		return { fabsf(x), fabsf(y), fabsf(z) };
 	}


### PR DESCRIPTION
## Summary
- include <cmath> to provide fabsf declarations
- change vec3_t::abs to inline non-constexpr to avoid constexpr fabsf issues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219bd2132c83288eab3191fcca7b32)