### PR TITLE
Fix CTF spawn guard and include menu status bar source

### DIFF
--- a/src/g_spawn.cpp
+++ b/src/g_spawn.cpp
@@ -1744,7 +1744,7 @@ entity parsing.
 =============
 */
 static void G_TestCTFSpawnPoints() {
-	if (!GTF(GTF_CTF))
+	if (!(GTF(GTF_CTF)))
 		return;
 
 	auto ensure_linked = [](const char *classname) {

--- a/src/game.vcxproj
+++ b/src/game.vcxproj
@@ -217,6 +217,7 @@
     <ClCompile Include="p_hud.cpp" />
     <ClCompile Include="p_hud_victor.cpp" />
     <ClCompile Include="p_menu.cpp" />
+    <ClCompile Include="p_menu_statusbar.cpp" />
     <ClCompile Include="p_move.cpp" />
     <ClCompile Include="p_trail.cpp" />
     <ClCompile Include="p_view.cpp" />

--- a/src/game.vcxproj.filters
+++ b/src/game.vcxproj.filters
@@ -276,6 +276,7 @@
       <Filter>monsters</Filter>
     </ClCompile>
     <ClCompile Include="p_menu.cpp" />
+    <ClCompile Include="p_menu_statusbar.cpp" />
     <ClCompile Include="g_menu.cpp" />
     <ClCompile Include="g_ctf.cpp" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- correct the CTF spawn-point guard to respect the gametype flag without precedence warnings
- include p_menu_statusbar.cpp in the Visual Studio project and filters to provide the status bar implementation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921a02f57448328983dfef51da9d59a)