### PR TITLE
Add null handling to COM_ParseEx

### DIFF
--- a/src/q_std.cpp
+++ b/src/q_std.cpp
@@ -54,6 +54,14 @@ char *COM_ParseEx(const char **data_p, const char *seps, char *buffer, size_t bu
 	size_t				stored_len;
 	const char *data;
 
+	if (!data_p || !*data_p)
+	{
+		buffer[0] = '\0';
+		if (data_p)
+			*data_p = nullptr;
+		return buffer;
+	}
+
 	data = *data_p;
 	len = 0;
 	stored_len = 0;


### PR DESCRIPTION
## Summary
- add an early null-pointer guard in COM_ParseEx before dereferencing data_p
- ensure the parser returns an empty token and resets the pointer when input data is absent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234b12e04483289dfb3fd528ac0f3b)