### PR TITLE
Add null check to COM_IsSeparator

### DIFF
--- a/src/q_std.cpp
+++ b/src/q_std.cpp
@@ -9,8 +9,18 @@
 
 g_fmt_data_t g_fmt_data;
 
+/*
+=============
+COM_IsSeparator
+
+Returns true if the specified character is a separator.
+=============
+*/
 bool COM_IsSeparator(char c, const char *seps)
 {
+	if (!seps)
+		return true;
+
 	if (!c)
 		return true;
 


### PR DESCRIPTION
## Summary
- add a defensive null check to COM_IsSeparator to treat missing separator lists as separators
- document the function with a header comment for clarity

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234b163cb083289510178aaede2f4f)