### PR TITLE
Add null name validation

### DIFF
--- a/src/g_save.cpp
+++ b/src/g_save.cpp
@@ -125,6 +125,11 @@ save_data_list_t::save_data_list_t(const char *name_in, save_data_tag_t tag_in, 
 	ptr(ptr_in),
 	next(nullptr),
 	valid(valid_in) {
+	assert(name_in);
+
+	if (!name_in)
+		gi.Com_Error("save data entry name cannot be null");
+
 	if (save_data_initialized && link)
 		gi.Com_Error("attempted to create save_data_list at runtime");
 


### PR DESCRIPTION
## Summary
- add a guard in the save_data_list_t constructor to reject null save data names before linking
- assert the provided save data names to catch invalid registrations early

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234b27a8dc83289a4838754cd8e983)