### PR TITLE
Handle monster spawning with arbitrary gravity

### DIFF
--- a/src/g_local.h
+++ b/src/g_local.h
@@ -3232,6 +3232,7 @@ gentity_t *CreateGroundMonster(const vec3_t &origin, const vec3_t &angles, const
 bool     FindSpawnPoint(const vec3_t &startpoint, const vec3_t &mins, const vec3_t &maxs, vec3_t &spawnpoint,
 	float maxMoveUp, bool drop = true, const vec3_t &gravityVector = { 0.0f, 0.0f, -1.0f });
 bool     CheckSpawnPoint(const vec3_t &origin, const vec3_t &mins, const vec3_t &maxs, const vec3_t &gravityVector = { 0.0f, 0.0f, -1.0f });
+bool     SpawnCheckAndDropToFloor(vec3_t &origin, const vec3_t &mins, const vec3_t &maxs, const vec3_t &gravityVector = { 0.0f, 0.0f, -1.0f });
 bool     CheckGroundSpawnPoint(const vec3_t &origin, const vec3_t &entMins, const vec3_t &entMaxs, float height,
 	const vec3_t &gravityVector = { 0.0f, 0.0f, -1.0f });
 void	 SpawnGrow_Spawn(const vec3_t &startpos, float start_size, float end_size);


### PR DESCRIPTION
## Summary
- add a helper to project spawn extents along arbitrary gravity directions
- update CheckSpawnPoint to use directional projections for non-standard gravity
- add SpawnCheckAndDropToFloor to drop spawn origins along the supplied gravity vector

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236dc92a0c8328aa1d80ddf1b99a00)