### PR TITLE
Load admins.txt for admin session detection

### DIFF
--- a/src/g_local.h
+++ b/src/g_local.h
@@ -3168,6 +3168,7 @@ void ChangeGametype(gametype_t gt);
 void GT_Changes();
 void SpawnEntities(const char *mapname, const char *entities, const char *spawnpoint);
 void G_LoadMOTD();
+bool G_IsAdminSocialId(const char *social_id);
 
 //
 // g_chase.cpp

--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -5,6 +5,10 @@
 #include "bots/bot_includes.h"
 #include "monsters/m_player.h"	// match starts
 #include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <string>
+#include <unordered_set>
 
 CHECK_GCLIENT_INTEGRITY;
 CHECK_ENTITY_INTEGRITY;
@@ -62,6 +66,8 @@ static cvar_t *maxclients;
 static cvar_t *maxentities;
 cvar_t *maxplayers;
 cvar_t *minplayers;
+
+static std::unordered_set<std::string> g_admin_social_ids;
 
 cvar_t *ai_allow_dm_spawn;
 cvar_t *ai_damage_scale;
@@ -619,37 +625,142 @@ static void InitGametype() {
 	bool force_dm = false;
 
 	if (g_gametype->integer < 0 || g_gametype->integer >= GT_NUM_GAMETYPES)
-		gi.cvar_forceset("g_gametype", G_Fmt("{}", clamp(g_gametype->integer, (int)GT_FIRST, (int)GT_LAST)).data());
-	
+	gi.cvar_forceset("g_gametype", G_Fmt("{}", clamp(g_gametype->integer, (int)GT_FIRST, (int)GT_LAST)).data());
+
 	if (ctf->integer) {
-		force_dm = true;
-		// force coop off
-		if (coop->integer)
-			gi.cvar_set(COOP, "0");
-		// force tdm off
-		if (teamplay->integer)
-			gi.cvar_set("teamplay", "0");
+	force_dm = true;
+	// force coop off
+	if (coop->integer)
+	gi.cvar_set(COOP, "0");
+	// force tdm off
+	if (teamplay->integer)
+	gi.cvar_set("teamplay", "0");
 	}
 	if (teamplay->integer) {
-		force_dm = true;
-		// force coop off
-		if (coop->integer)
-			gi.cvar_set(COOP, "0");
+	force_dm = true;
+	// force coop off
+	if (coop->integer)
+	gi.cvar_set(COOP, "0");
 	}
 
 	if (force_dm && !deathmatch->integer) {
-		gi.Com_Print("Forcing deathmatch.\n");
-		gi.cvar_forceset("deathmatch", "1");
+	gi.Com_Print("Forcing deathmatch.\n");
+	gi.cvar_forceset("deathmatch", "1");
 	}
 
 	// force even maxplayers value during teamplay
 	if (Teams()) {
-		int pmax = maxplayers->integer;
+	int pmax = maxplayers->integer;
 
-		if (pmax != floor(pmax / 2))
-			gi.cvar_set("maxplayers", G_Fmt("{}", floor(pmax / 2) * 2).data());
+	if (pmax != floor(pmax / 2))
+	gi.cvar_set("maxplayers", G_Fmt("{}", floor(pmax / 2) * 2).data());
 	}
-}
+	}
+
+/*
+=============
+G_Admins_NormalizeId
+
+Converts a social ID to lowercase for comparison.
+=============
+*/
+static std::string G_Admins_NormalizeId(const std::string &input) {
+	std::string normalized;
+	normalized.reserve(input.size());
+
+	for (char ch : input)
+	normalized.push_back((char)std::tolower((uint8_t)ch));
+
+	return normalized;
+	}
+
+/*
+=============
+G_Admins_TrimLine
+
+Strips comments and whitespace from a config line.
+=============
+*/
+static std::string G_Admins_TrimLine(const std::string &line) {
+	std::string trimmed = line;
+
+	size_t comment = trimmed.find_first_of("#;");
+	if (comment != std::string::npos)
+	trimmed = trimmed.substr(0, comment);
+
+	size_t start = trimmed.find_first_not_of(" \t\r\n");
+	if (start == std::string::npos)
+	return {};
+
+	size_t end = trimmed.find_last_not_of(" \t\r\n");
+	return trimmed.substr(start, end - start + 1);
+	}
+
+/*
+=============
+G_IsAdminSocialId
+
+Checks whether the provided social ID is in the admin list.
+=============
+*/
+bool G_IsAdminSocialId(const char *social_id) {
+	if (!social_id || !*social_id)
+	return false;
+
+	std::string normalized = G_Admins_NormalizeId(social_id);
+	return g_admin_social_ids.find(normalized) != g_admin_social_ids.end();
+	}
+
+/*
+=============
+G_LoadAdminList
+
+Loads admins from the admins.txt configuration file.
+=============
+*/
+static void G_LoadAdminList() {
+	g_admin_social_ids.clear();
+
+	const char *filename = "admins.txt";
+	std::ifstream file(filename);
+
+	if (!file.is_open()) {
+	gi.Com_PrintFmt("G_LoadAdminList: {} not found, skipping admin preload.\n", filename);
+	return;
+	}
+
+	size_t line_number = 0;
+	std::string line;
+
+	while (std::getline(file, line)) {
+	++line_number;
+
+	std::string trimmed = G_Admins_TrimLine(line);
+	if (trimmed.empty())
+	continue;
+
+	if (trimmed.size() >= MAX_INFO_VALUE) {
+	gi.Com_PrintFmt("G_LoadAdminList: line {} exceeds maximum length, ignoring.\n", line_number);
+	continue;
+	}
+
+	if (trimmed.find_first_of(" \t") != std::string::npos) {
+	gi.Com_PrintFmt("G_LoadAdminList: unexpected whitespace on line {}, ignoring.\n", line_number);
+	continue;
+	}
+
+	std::string normalized = G_Admins_NormalizeId(trimmed);
+
+	if (normalized.empty()) {
+	gi.Com_PrintFmt("G_LoadAdminList: invalid entry on line {}, ignoring.\n", line_number);
+	continue;
+	}
+
+	g_admin_social_ids.insert(normalized);
+	}
+
+	gi.Com_PrintFmt("G_LoadAdminList: loaded {} admin entr{}.\n", g_admin_social_ids.size(), g_admin_social_ids.size() == 1 ? "y" : "ies");
+	}
 
 void ChangeGametype(gametype_t gt) {
 	switch (gt) {
@@ -1056,6 +1167,8 @@ g_dm_item_respawn_rate = gi.cvar("g_dm_item_respawn_rate", "1.0", CVAR_NOFLAGS);
 	g_warmup_ready_percentage = gi.cvar("g_warmup_ready_percentage", "0.51f", CVAR_NOFLAGS);
 	g_weapon_projection = gi.cvar("g_weapon_projection", "0", CVAR_NOFLAGS);
 	g_weapon_respawn_time = gi.cvar("g_weapon_respawn_time", "30", CVAR_NOFLAGS);
+
+	G_LoadAdminList();
 
 	bot_name_prefix = gi.cvar("bot_name_prefix", "B|", CVAR_NOFLAGS);
 

--- a/src/p_client.cpp
+++ b/src/p_client.cpp
@@ -3794,11 +3794,9 @@ bool ClientConnect(gentity_t* ent, char* userinfo, const char* social_id, bool i
 
 	// entity 1 is always server host, so make admin
 	if (ent == &g_entities[1])
-		ent->client->sess.admin = true;
-	else {
-		//TODO: check admins.txt for social_id
-
-	}
+	ent->client->sess.admin = true;
+	else if (G_IsAdminSocialId(social_id))
+	ent->client->sess.admin = true;
 
 	// count current clients and rank for scoreboard
 	CalculateRanks();


### PR DESCRIPTION
## Summary
- load admin social IDs from admins.txt during game initialization and ignore malformed entries
- add helper to check incoming social IDs against the loaded admin list
- mark connecting clients as admins when their social ID matches the configured list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236e2ed2ec83288187f56bdcb9e275)