### PR TITLE
Cache entity string for faster match resets

### DIFF
--- a/src/g_cmds.cpp
+++ b/src/g_cmds.cpp
@@ -3403,8 +3403,6 @@ static void Cmd_SetMap_f(gentity_t *ent) {
 	ExitLevel();
 }
 
-extern void ClearWorldEntities();
-
 /*
 =============
 Cmd_MapRestart_f
@@ -3415,9 +3413,12 @@ Reset the match and world state before reloading the current map.
 static void Cmd_MapRestart_f(gentity_t *ent) {
 	gi.Broadcast_Print(PRINT_HIGH, "[ADMIN]: Session reset.\n");
 
+	G_SaveLevelEntstring();
 	Match_Reset();
-	ClearWorldEntities();
-	SpawnEntities(level.mapname, level.entstring.c_str(), nullptr);
+
+	if (G_ResetLevelFromSavedEntstring())
+		return;
+
 	gi.AddCommandString(G_Fmt("gamemap {}\n", level.mapname).data());
 }
 

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -3167,6 +3167,9 @@ bool InAMatch();
 void ChangeGametype(gametype_t gt);
 void GT_Changes();
 void SpawnEntities(const char *mapname, const char *entities, const char *spawnpoint);
+void ClearWorldEntities();
+void G_SaveLevelEntstring();
+bool G_ResetLevelFromSavedEntstring();
 void G_LoadMOTD();
 
 //

--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -34,6 +34,8 @@ gentity_t *g_entities;
 
 cvar_t *hostname;
 
+static std::string saved_level_entstring;
+
 cvar_t *deathmatch;
 cvar_t *ctf;
 cvar_t *teamplay;
@@ -803,14 +805,48 @@ void GT_Changes() {
 		gt_check = (gametype_t)g_gametype->integer;
 	} else return;
 
-	//TODO: save ent string so we can simply reload it and Match_Reset
-	//gi.AddCommandString("map_restart");
-
+	G_SaveLevelEntstring();
 	gi.AddCommandString(G_Fmt("gamemap {}\n", level.mapname).data());
 
 	GT_PrecacheAssets();
 	GT_SetLongName();
 	gi.LocBroadcast_Print(PRINT_CENTER, "{}", level.gametype_name);
+}
+
+/*
+=============
+G_SaveLevelEntstring
+
+Preserve the currently loaded entity string so it can be reused when rebuilding the level without a full map reload.
+=============
+*/
+void G_SaveLevelEntstring() {
+	if (!level.entstring.empty())
+		saved_level_entstring = level.entstring;
+}
+
+/*
+=============
+G_ResetLevelFromSavedEntstring
+
+Rebuild the level using the cached entity string if available, avoiding a full map reload. Returns true when the reset completed using the cached data.
+=============
+*/
+bool G_ResetLevelFromSavedEntstring() {
+	const char *entities = nullptr;
+
+	if (!saved_level_entstring.empty())
+		entities = saved_level_entstring.c_str();
+	else if (!level.entstring.empty())
+		entities = level.entstring.c_str();
+
+	if (!entities)
+		return false;
+
+	ClearWorldEntities();
+	SpawnEntities(level.mapname, entities, nullptr);
+
+	return true;
 }
 
 /*

--- a/src/g_spawn.cpp
+++ b/src/g_spawn.cpp
@@ -1572,7 +1572,7 @@ static void G_LocateSpawnSpots(void) {
 
 /*
 =============
-ParseWorldEntityString
+	ParseWorldEntityString
 
 Loads the base entity string for the level and optionally overrides it with
 an external .ent file.
@@ -1869,6 +1869,8 @@ void SpawnEntities(const char *mapname, const char *entities, const char *spawnp
 
 	level.entstring = new_entstring;
 	ParseWorldEntityString(mapname, RS(RS_Q3A));
+
+	G_SaveLevelEntstring();
 
 	level.is_n64 = strncmp(level.mapname, "q64/", 4) == 0;
 


### PR DESCRIPTION
## Summary
- cache the current map entity string whenever levels are parsed or gametypes change
- add helpers to restore the level from the cached entity data and use them for map restarts to avoid full reloads when possible

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236e3c96cc8328a2edc61a335294fa)