### PR TITLE
Refactor findradius center distance calculation

### DIFF
--- a/src/g_utils.cpp
+++ b/src/g_utils.cpp
@@ -45,10 +45,6 @@ findradius (origin, radius)
 =================
 */
 gentity_t* findradius(gentity_t* from, const vec3_t& org, float rad) {
-	const auto compute_center = [](const gentity_t* ent) {
-		return ent->s.origin + (ent->mins + ent->maxs) * 0.5f;
-	};
-
 	if (!from)
 		from = g_entities;
 	else
@@ -58,7 +54,8 @@ gentity_t* findradius(gentity_t* from, const vec3_t& org, float rad) {
 			continue;
 		if (from->solid == SOLID_NOT)
 			continue;
-		const vec3_t eorg = org - compute_center(from);
+		const vec3_t entity_center = from->s.origin + (from->mins + from->maxs) * 0.5f;
+		const vec3_t eorg = org - entity_center;
 		if (eorg.length() > rad)
 			continue;
 		return from;
@@ -66,6 +63,7 @@ gentity_t* findradius(gentity_t* from, const vec3_t& org, float rad) {
 
 	return nullptr;
 }
+
 
 
 


### PR DESCRIPTION
## Summary
- compute entity centers directly for radius checks
- simplify findradius distance logic to a single vector length comparison

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923712f412883288503e117735a3e70)