### PR TITLE
Handle MOTD buffer lifecycle

### DIFF
--- a/src/g_local.h
+++ b/src/g_local.h
@@ -1455,6 +1455,7 @@ struct game_locals_t {
 
 	gametype_t	gametype;
 	std::string motd;
+	char *motd_buffer = nullptr;
 	int motd_mod_count = 0;
 
 	ruleset_t	ruleset;

--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -606,6 +606,13 @@ Loads the server message of the day text into persistent memory.
 =============
 */
 void G_LoadMOTD() {
+	if (game.motd_buffer) {
+		gi.TagFree(game.motd_buffer);
+		game.motd_buffer = nullptr;
+	}
+
+	game.motd.clear();
+
 	// load up ent override
 	const char *name = G_Fmt("baseq2/{}", g_motd_filename->string[0] ? g_motd_filename->string : "motd.txt").data();
 	FILE *f = fopen(name, "rb");
@@ -638,14 +645,19 @@ void G_LoadMOTD() {
 		fclose(f);
 
 		if (valid) {
-			game.motd = (const char *)buffer;
+			game.motd_buffer = buffer;
+			game.motd.assign(buffer, length);
 			game.motd_mod_count++;
 			if (g_verbose->integer)
 				gi.Com_PrintFmt("{}: MotD file verified and loaded: \"{}\"\n", __FUNCTION__, name);
 		} else {
 			gi.Com_PrintFmt("{}: MotD file load error for \"{}\", discarding.\n", __FUNCTION__, name);
-			if (buffer)
+			if (buffer) {
 				gi.TagFree(buffer);
+				buffer = nullptr;
+			}
+			game.motd_buffer = nullptr;
+			game.motd.clear();
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- free any existing MOTD allocation before loading new content and track the buffer owner
- clear MOTD state when loading fails to prevent stale data being used

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925db2135e8832898807d22de9b549a)