### PR TITLE
Handle Horde rounds when no active players remain

### DIFF
--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -574,17 +574,13 @@ bool Horde_LivesEnabled() {
 =============
 Horde_NoLivesRemain
 
-Returns true when every playing client is out of lives or eliminated.
+Returns true when no active players are present or when every playing client is out of lives or eliminated.
 =============
 */
 bool Horde_NoLivesRemain(const std::vector<player_life_state_t> &states) {
-	bool	have_players = false;
-
 	for (const auto &state : states) {
 		if (!state.playing)
 			continue;
-
-		have_players = true;
 
 		if (state.health > 0)
 			return false;
@@ -593,7 +589,7 @@ bool Horde_NoLivesRemain(const std::vector<player_life_state_t> &states) {
 			return false;
 	}
 
-	return have_players;
+	return true;
 }
 // =================================================
 


### PR DESCRIPTION
## Summary
- ensure Horde_NoLivesRemain reports no lives remaining when all active players have left
- update the Horde_NoLivesRemain comment to describe the new behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925db26efbc83289d3e906047d3bbdc)