### PR TITLE
Add null check for menu status bar entries

### DIFF
--- a/src/p_menu_statusbar.cpp
+++ b/src/p_menu_statusbar.cpp
@@ -115,6 +115,9 @@ size_t P_Menu_BuildStatusBar(const menu_hnd_t *hnd, char *layout, size_t layout_
 
 	layout[0] = '\0';
 
+	if (!hnd->entries)
+		return 0;
+
 	P_Menu_Appendf(layout, layout_size, "xv %d yv %d picn %s ", 32, 8, "inventory");
 
 	bool alt = false;


### PR DESCRIPTION
## Summary
- add a null check for menu status bar entries and return early when absent to avoid crashes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925db6164008328a0b0110186118ad4)