### PR TITLE
Adjust status bar caret alignment

### DIFF
--- a/src/p_menu_statusbar.cpp
+++ b/src/p_menu_statusbar.cpp
@@ -35,11 +35,10 @@ size_t Q_strlcpy(char *dst, const char *src, size_t siz)
 			*d = '\0';
 		while (*s++)
 			;
-	}
+		}
 
 	return static_cast<size_t>(s - src - 1);
-}
-
+		}
 /*
 =============
 Q_strlcat
@@ -67,19 +66,17 @@ size_t Q_strlcat(char *dst, const char *src, size_t siz)
 		if (n != 1) {
 			*d++ = *s;
 			n--;
-		}
-		s++;
-	}
+		}		s++;
+}
 
 	*d = '\0';
 
 	return dlen + static_cast<size_t>(s - src);
-}
-#endif
+		}#endif
 
 /*
 =============
-P_Menu_Appendf
+			P_Menu_Appendf
 
 Appends formatted text to a layout buffer while ensuring the destination is
 not overrun.
@@ -98,8 +95,7 @@ static bool P_Menu_Appendf(char *layout, size_t layout_size, const char *fmt, ..
 	va_end(args);
 
 	return Q_strlcat(layout, chunk.data(), layout_size) < layout_size;
-}
-
+		}
 /*
 =============
 P_Menu_BuildStatusBar
@@ -131,24 +127,25 @@ size_t P_Menu_BuildStatusBar(const menu_hnd_t *hnd, char *layout, size_t layout_
 			alt = true;
 			t++;
 		}
-
 		const int y = 32 + i * 8;
 		int x = 64;
+		int caret_x = 56;
 		const char *loc_func = "loc_string";
 
 		if (p->align == MENU_ALIGN_CENTER) {
 			x = 0;
+			caret_x = 152;
 			loc_func = "loc_cstring";
 		} else if (p->align == MENU_ALIGN_RIGHT) {
 			x = 260;
+			caret_x = 252;
 			loc_func = "loc_rstring";
 		}
-
 		P_Menu_Appendf(layout, layout_size, "yv %d ", y);
 		P_Menu_Appendf(layout, layout_size, "xv %d %s%s 1 \"%s\" \"%s\" ", x, loc_func, (hnd->cur == i || alt) ? "2" : "", t, p->text_arg1);
 
 		if (hnd->cur == i)
-			P_Menu_Appendf(layout, layout_size, "xv %d string2 \"%s\" ", 56, ">\"");
+			P_Menu_Appendf(layout, layout_size, "xv %d string2 \"%s\" ", caret_x, ">\"");
 
 		alt = false;
 	}


### PR DESCRIPTION
## Summary
- add caret position calculations aligned with each menu entry type
- keep status bar highlights next to active labels for all alignments

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925db63ce6883289ac04ce90cce102a)