### PR TITLE
Stop emitting JSON warnings after fatal errors

### DIFF
--- a/src/g_save.cpp
+++ b/src/g_save.cpp
@@ -252,8 +252,11 @@ Prints JSON load errors with the current stack context, optionally treating them
 =============
 */
 void json_print_error(const char *field, const char *message, bool fatal) {
-	if (fatal || g_strict_saves->integer)
+	if (fatal || g_strict_saves->integer) {
 		gi.Com_ErrorFmt("Error loading JSON\n{}.{}: {}", json_error_stack, field, message);
+
+		return;
+	}
 
 	gi.Com_PrintFmt("Warning loading JSON\n{}.{}: {}\n", json_error_stack, field, message);
 }


### PR DESCRIPTION
## Summary
- add an early return when fatal or strict save errors occur to avoid emitting warning messages afterward

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925db9445108328b104f4a77864ac31)