### PR TITLE
Fix vampiric regen cap rounding and add regression test

### DIFF
--- a/src/g_items.cpp
+++ b/src/g_items.cpp
@@ -1140,7 +1140,7 @@ void Tech_ApplyAutoDoc(gentity_t* ent) {
 	bool		mod = g_instagib->integer || g_nadefest->integer;
 	bool		has_autodoc = false;
 	bool		no_health = mod || GTF(GTF_ARENA) || g_no_health->integer;
-	int			max = g_vampiric_damage->integer ? ceil(g_vampiric_health_max->integer / 2) : mod ? 100 : 150;
+	int			max = G_GetTechRegenMax(g_vampiric_health_max->integer, g_vampiric_damage->integer, mod);
 
 	cl = ent->client;
 	if (!cl)

--- a/src/g_items_limits.h
+++ b/src/g_items_limits.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+
 /*
 =============
 G_GetHoldableMax
@@ -11,6 +13,21 @@ constexpr int G_GetHoldableMax(int override_max, int item_max, int fallback)
 {
 	int max_value = override_max > 0 ? override_max : item_max;
 	return max_value > 0 ? max_value : fallback;
+}
+
+/*
+=============
+G_GetTechRegenMax
+
+Returns the regeneration cap applied when the Autodoc tech is active.
+=============
+*/
+inline int G_GetTechRegenMax(int vampiric_health_max, bool vampiric_damage_enabled, bool mod_enabled)
+{
+	if (vampiric_damage_enabled)
+		return (int)ceil(static_cast<float>(vampiric_health_max) / 2.0f);
+
+	return mod_enabled ? 100 : 150;
 }
 
 static_assert(G_GetHoldableMax(3, 1, 1) == 3, "Override max should win when positive.");

--- a/tests/autodoc_regen_tests.cpp
+++ b/tests/autodoc_regen_tests.cpp
@@ -1,0 +1,17 @@
+#include "../src/g_items_limits.h"
+#include <cassert>
+
+/*
+=============
+main
+
+Verifies vampiric regen cap rounds up for odd maximums.
+=============
+*/
+int main()
+{
+	assert(G_GetTechRegenMax(101, true, false) == 51);
+	assert(G_GetTechRegenMax(100, true, false) == 50);
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- compute the Autodoc regeneration cap via a shared helper that rounds vampiric max health up before halving
- expose the new calculation helper in the item limits header for reuse
- add a regression test confirming odd vampiric caps round up correctly

## Testing
- g++ -std=c++17 -Isrc tests/autodoc_regen_tests.cpp -o /tmp/autodoc_regen_test
- /tmp/autodoc_regen_test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925dba01ea4832894e2e789d6f5f78e)