### PR TITLE
Handle empty horde rosters in life check

### DIFF
--- a/src/g_main.cpp
+++ b/src/g_main.cpp
@@ -593,7 +593,7 @@ bool Horde_NoLivesRemain(const std::vector<player_life_state_t> &states) {
 			return false;
 	}
 
-	return have_players;
+	return true;
 }
 // =================================================
 

--- a/tests/horde_lives_tests.cpp
+++ b/tests/horde_lives_tests.cpp
@@ -73,6 +73,20 @@ static void TestNoLivesTriggersElimination()
 
 /*
 =============
+TestEmptyRosterTriggersElimination
+
+Ensures waves complete when no playing clients remain.
+=============
+*/
+static void TestEmptyRosterTriggersElimination()
+{
+	std::vector<player_life_state_t> states;
+
+	Expect(Horde_NoLivesRemain(states), "No playing clients should end the wave");
+}
+
+/*
+=============
 main
 
 Runs Horde life exhaustion regression checks.
@@ -83,6 +97,7 @@ int main()
 	TestAlivePlayerPreventsElimination();
 	TestRemainingLivesPreventFailure();
 	TestNoLivesTriggersElimination();
+	TestEmptyRosterTriggersElimination();
 
 	return g_failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- ensure `Horde_NoLivesRemain` treats empty rosters as complete to prevent stalled waves
- add a unit test covering the no-player horde scenario

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925dc45537c83288a21c70f88ed425b)