### PR TITLE
Ensure spectators inherit team chat prefix

### DIFF
--- a/src/g_utils.cpp
+++ b/src/g_utils.cpp
@@ -183,17 +183,23 @@ void BroadcastFriendlyMessage(team_t team, const char* msg) {
 
 	for (auto ce : active_clients()) {
 		const bool playing = ClientIsPlaying(ce->client);
+		bool following_team = false;
 		if (!playing) {
 			if (!Teams())
 				continue;
 			gentity_t* follow = ce->client->follow_target;
 			if (!follow || !follow->client || follow->client->sess.team != team)
 				continue;
+
+			following_team = true;
 		}
 		else if (Teams() && ce->client->sess.team != team) {
 			continue;
 		}
-		gi.LocClient_Print(ce, PRINT_HIGH, G_Fmt("{}{}", playing && ce->client->sess.team != TEAM_SPECTATOR ? "[TEAM]: " : "", msg).data());
+
+		const bool is_team_player = playing && ce->client->sess.team == team && ce->client->sess.team != TEAM_SPECTATOR;
+		const bool prefix_team = FriendlyMessageShouldPrefixTeam(Teams(), team == TEAM_SPECTATOR, playing, is_team_player, following_team);
+		gi.LocClient_Print(ce, PRINT_HIGH, G_Fmt("{}{}", prefix_team ? "[TEAM]: " : "", msg).data());
 	}
 }
 

--- a/src/g_utils_friendly_message.h
+++ b/src/g_utils_friendly_message.h
@@ -13,3 +13,23 @@ inline bool FriendlyMessageHasText(const char *msg)
 {
 	return msg && *msg && strnlen(msg, 256) < 256;
 }
+
+/*
+=============
+FriendlyMessageShouldPrefixTeam
+
+Determines if a friendly message should include a team prefix for the
+recipient based on game mode, target team, and how the recipient is viewing
+the game.
+=============
+*/
+inline bool FriendlyMessageShouldPrefixTeam(bool teams_active, bool target_is_spectator, bool recipient_is_playing, bool recipient_on_team, bool recipient_following_team)
+{
+	if (!teams_active || target_is_spectator)
+		return false;
+
+	if (recipient_is_playing)
+		return recipient_on_team;
+
+	return recipient_following_team;
+}

--- a/tests/friendly_message_tests.cpp
+++ b/tests/friendly_message_tests.cpp
@@ -24,5 +24,9 @@ int main()
 	bounded[255] = '\0';
 	assert(FriendlyMessageHasText(bounded));
 
+	assert(FriendlyMessageShouldPrefixTeam(true, false, false, false, true));
+	assert(!FriendlyMessageShouldPrefixTeam(true, false, false, false, false));
+	assert(FriendlyMessageShouldPrefixTeam(true, false, true, true, false));
+
 	return 0;
 }


### PR DESCRIPTION
## Summary
- add a helper to determine when friendly messages should include a team prefix
- ensure spectators following a team receive prefixed team chat alongside players
- extend friendly message regression coverage for spectator follow cases

## Testing
- g++ -std=c++17 -Isrc tests/friendly_message_tests.cpp -o /tmp/friendly_message_tests && /tmp/friendly_message_tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925dc553e40832887d21da242532ee9)