### PR TITLE
Handle pcfg file length errors

### DIFF
--- a/src/p_client.cpp
+++ b/src/p_client.cpp
@@ -307,15 +307,27 @@ static void PCfg_ClientInitPConfig(gentity_t* ent) {
 	FILE* f = fopen(name, "rb");
 	char* buffer = nullptr;
 	if (f != NULL) {
-		size_t length;
+		size_t length = 0;
 		size_t read_length;
+		long file_length = 0;
 
-		fseek(f, 0, SEEK_END);
-		length = ftell(f);
-		fseek(f, 0, SEEK_SET);
-
-		if (length > 0x40000) {
+		if (fseek(f, 0, SEEK_END) != 0) {
 			cfg_valid = false;
+		}
+		if (cfg_valid) {
+			file_length = ftell(f);
+			if (file_length < 0) {
+				cfg_valid = false;
+			}
+		}
+		if (cfg_valid && fseek(f, 0, SEEK_SET) != 0) {
+			cfg_valid = false;
+		}
+		if (cfg_valid) {
+			length = static_cast<size_t>(file_length);
+			if (length > 0x40000) {
+				cfg_valid = false;
+			}
 		}
 		if (cfg_valid) {
 			buffer = (char*)gi.TagMalloc(length + 1, TAG_GAME);


### PR DESCRIPTION
## Summary
- validate player config file length by checking ftell on a signed type and rejecting negative offsets
- treat fseek/ftell failures or oversized files as invalid configs to avoid reading or allocating buffers

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692611219f988328b48e3eb59ae293fb)