### PR TITLE
Handle invalid player configs by regenerating defaults

### DIFF
--- a/src/p_client.cpp
+++ b/src/p_client.cpp
@@ -398,9 +398,27 @@ static void PCfg_ClientInitPConfig(gentity_t* ent) {
 			if (buffer) {
 				gi.TagFree(buffer);
 			}
-			gi.Com_PrintFmt("{}: Player config load error for \"{}\", discarding.\n", __FUNCTION__, name);
+			gi.Com_PrintFmt("{}: Player config load error for \"{}\", regenerating defaults.\n", __FUNCTION__, name);
+			if (file_exists) {
+				if (std::remove(name) != 0) {
+					FILE* truncate = fopen(name, "wb");
+					if (truncate) {
+						fclose(truncate);
+						gi.Com_PrintFmt("{}: Truncated bad player config \"{}\".\n", __FUNCTION__, name);
+					}
+					else {
+						gi.Com_PrintFmt("{}: Failed to remove or truncate bad config \"{}\".\n", __FUNCTION__, name);
+					}
+				}
+				else {
+					gi.Com_PrintFmt("{}: Removed bad player config \"{}\".\n", __FUNCTION__, name);
+				}
+			}
+			ent->client->sess.pc = default_pc;
+			PCfg_WriteConfig(ent);
 			return;
 		}
+	}
 
 		if (buffer && length) {
 			char* cursor = buffer;


### PR DESCRIPTION
## Summary
- log player config load failures and clean up invalid config files
- regenerate default player configs after removal/truncation to keep connections working

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692612a523348328b5ebb812d21efe59)