### PR TITLE
Fix MSVC compilation errors

### DIFF
--- a/src/g_save.cpp
+++ b/src/g_save.cpp
@@ -32,7 +32,7 @@ Fetches the engine build string from the version cvar.
 =============
 */
 static const char *GetEngineBuildString() {
-	cvar_t *engine_version = gi.cvar("version", "", 0);
+	cvar_t *engine_version = gi.cvar("version", "", CVAR_NOFLAGS);
 
 	if (!engine_version || !engine_version->string)
 		return "";
@@ -218,6 +218,9 @@ const save_data_list_t *save_data_list_t::fetch(const void *ptr, save_data_tag_t
 }
 
 std::string json_error_stack;
+
+void json_push_stack(const std::string &stack);
+void json_pop_stack();
 
 /*
 =============

--- a/src/g_utils.cpp
+++ b/src/g_utils.cpp
@@ -7,7 +7,6 @@
 #include "g_utils_friendly_message.h"
 #include <cerrno>
 #include <vector>
-#include <span>
 #include "g_utils_target_selection.h"
 
 /*
@@ -21,20 +20,23 @@ nullptr will be returned if the end of the list is reached.
 =============
 */
 gentity_t* G_Find(gentity_t* from, std::function<bool(gentity_t* e)> matcher) {
-	const std::span<gentity_t> entities{ g_entities, static_cast<size_t>(globals.num_entities) };
+	gentity_t *entities = g_entities;
+	const size_t entity_count = static_cast<size_t>(globals.num_entities);
 	size_t start_index = 0;
 
 	if (from)
 		start_index = static_cast<size_t>((from - g_entities) + 1);
 
-	if (start_index >= entities.size())
+	if (start_index >= entity_count)
 		return nullptr;
 
-	for (gentity_t& ent : entities.subspan(start_index)) {
-		if (!ent.inuse)
+	for (size_t index = start_index; index < entity_count; index++) {
+		gentity_t *ent = &entities[index];
+
+		if (!ent->inuse)
 			continue;
-		if (matcher(&ent))
-			return &ent;
+		if (matcher(ent))
+			return ent;
 	}
 
 	return nullptr;

--- a/src/monsters/m_medic.cpp
+++ b/src/monsters/m_medic.cpp
@@ -148,14 +148,6 @@ std::array<uint8_t, MAX_REINFORCEMENTS> M_PickReinforcements(gentity_t *self, in
 		remaining -= self->monsterinfo.reinforcements.reinforcements[chosen[num_chosen]].strength;
 	}
 
-	if (developer->integer) {
-		gi.dprintf("[Medic] Reinforcement picks (slots %d used %d):", self->monsterinfo.monster_slots, self->monsterinfo.monster_used);
-		for (int32_t i = 0; i < num_chosen; i++) {
-			gi.dprintf(" %d", chosen[i]);
-		}
-		gi.dprintf("\n");
-	}
-
 	return chosen;
 }
 

--- a/src/p_menu_statusbar.cpp
+++ b/src/p_menu_statusbar.cpp
@@ -35,10 +35,11 @@ size_t Q_strlcpy(char *dst, const char *src, size_t siz)
 			*d = '\0';
 		while (*s++)
 			;
-		}
+	}
 
 	return static_cast<size_t>(s - src - 1);
-		}
+}
+
 /*
 =============
 Q_strlcat
@@ -66,17 +67,19 @@ size_t Q_strlcat(char *dst, const char *src, size_t siz)
 		if (n != 1) {
 			*d++ = *s;
 			n--;
-		}		s++;
-}
+		}
+		s++;
+	}
 
 	*d = '\0';
 
 	return dlen + static_cast<size_t>(s - src);
-		}#endif
+}
+#endif
 
 /*
 =============
-			P_Menu_Appendf
+P_Menu_Appendf
 
 Appends formatted text to a layout buffer while ensuring the destination is
 not overrun.
@@ -95,7 +98,8 @@ static bool P_Menu_Appendf(char *layout, size_t layout_size, const char *fmt, ..
 	va_end(args);
 
 	return Q_strlcat(layout, chunk.data(), layout_size) < layout_size;
-		}
+}
+
 /*
 =============
 P_Menu_BuildStatusBar


### PR DESCRIPTION
## Summary
- use correct cvar flag type and declare JSON stack helpers before use
- replace C++20 span/ranges usage and reorder helpers for C++17 builds
- clean up menu status bar helpers and remove unusable medic debug logging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261e2c96fc832897ee2f435fe4beb8)