### PR TITLE
Fix damage indicator clamp type

### DIFF
--- a/src/p_view.cpp
+++ b/src/p_view.cpp
@@ -234,8 +234,10 @@ void P_DamageFeedback(gentity_t *player) {
 		for (size_t i = 0; i < client->num_damage_indicators; i++) {
 			auto &indicator = client->damage_indicators[i];
 
+			const int32_t average_damage = (indicator.health + indicator.power + indicator.armor) / 3;
+
 			// encode total damage into 5 bits
-			uint8_t encoded = std::clamp((indicator.health + indicator.power + indicator.armor) / 3, 1, 0x1F);
+			uint8_t encoded = static_cast<uint8_t>(std::clamp<int32_t>(average_damage, 1, 0x1F));
 
 			// encode types in the latter 3 bits
 			if (indicator.health)


### PR DESCRIPTION
## Summary
- ensure damage indicator encoding clamps damage totals using an explicit int32_t and safe cast before packing the byte

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692877a5b79c8328885452a42cf6d327)