### PR TITLE
Replace menu text buffers with bounded strings

### DIFF
--- a/src/p_menu.h
+++ b/src/p_menu.h
@@ -1,8 +1,9 @@
 // Copyright (c) ZeniMax Media Inc.
 // Licensed under the GNU General Public License 2.0.
 
-#include <array>
 #include <cstddef>
+#include <cstring>
+#include <string>
 
 struct gentity_t;
 
@@ -27,32 +28,30 @@ struct menu_hnd_t {
 
 using SelectFunc_t = void (*)(gentity_t *ent, menu_hnd_t *hnd);
 
+constexpr size_t MENU_TEXT_MAX = 256;
+constexpr size_t MENU_TEXT_ARG_MAX = 64;
+
 /*
 =============
 P_Menu_InitText
 
-Creates a fixed-size character buffer from the provided source string.
+Creates a bounded std::string from the provided source string.
 =============
 */
 template <size_t N>
-constexpr std::array<char, N> P_Menu_InitText(const char *src) {
-	std::array<char, N> dest{};
+inline std::string P_Menu_InitText(const char *src) {
+	if (!src)
+		return {};
 
-	size_t i = 0;
-	if (src) {
-		for (; src[i] != '\0' && i + 1 < dest.size(); ++i)
-			dest[i] = src[i];
-	}
-	dest[i] = '\0';
-
-	return dest;
+	const size_t length = std::strnlen(src, N - 1);
+	return std::string(src, length);
 }
 
 struct menu_t {
-	std::array<char, 256>	text;	// 26]; // [64];
-	int				align;
+	std::string		text;
+	int			align;
 	SelectFunc_t	SelectFunc;
-	std::array<char, 64>	text_arg1;
+	std::string		text_arg1;
 };
 
 /*
@@ -62,8 +61,8 @@ P_Menu_CreateEntry
 Initializes a menu_t instance with bounded text and optional callback data.
 =============
 */
-constexpr menu_t P_Menu_CreateEntry(const char *text, int align, SelectFunc_t SelectFunc = nullptr, const char *text_arg1 = "") {
-	return { P_Menu_InitText<256>(text), align, SelectFunc, P_Menu_InitText<64>(text_arg1) };
+inline menu_t P_Menu_CreateEntry(const char *text, int align, SelectFunc_t SelectFunc = nullptr, const char *text_arg1 = "") {
+	return { P_Menu_InitText<MENU_TEXT_MAX>(text), align, SelectFunc, P_Menu_InitText<MENU_TEXT_ARG_MAX>(text_arg1) };
 }
 
 void		P_Menu_Dirty();

--- a/src/p_menu_statusbar.cpp
+++ b/src/p_menu_statusbar.cpp
@@ -125,10 +125,10 @@ size_t P_Menu_BuildStatusBar(const menu_hnd_t *hnd, char *layout, size_t layout_
 	for (int i = 0; i < hnd->num; i++) {
 		const menu_t *p = hnd->entries + i;
 
-if (!p->text[0])
-continue;
+		if (p->text.empty())
+			continue;
 
-const char *t = p->text.data();
+		const char *t = p->text.c_str();
 
 		if (*t == '*') {
 			alt = true;
@@ -149,7 +149,7 @@ const char *t = p->text.data();
 			loc_func = "loc_rstring";
 		}
 		P_Menu_Appendf(layout, layout_size, "yv %d ", y);
-P_Menu_Appendf(layout, layout_size, "xv %d %s%s 1 \"%s\" \"%s\" ", x, loc_func, (hnd->cur == i || alt) ? "2" : "", t, p->text_arg1.data());
+		P_Menu_Appendf(layout, layout_size, "xv %d %s%s 1 \"%s\" \"%s\" ", x, loc_func, (hnd->cur == i || alt) ? "2" : "", t, p->text_arg1.c_str());
 
 		if (hnd->cur == i)
 			P_Menu_Appendf(layout, layout_size, "xv %d string2 \"%s\" ", caret_x, ">\"");
@@ -159,3 +159,4 @@ P_Menu_Appendf(layout, layout_size, "xv %d %s%s 1 \"%s\" \"%s\" ", x, loc_func, 
 
 	return std::strlen(layout);
 }
+


### PR DESCRIPTION
## Summary
- replace menu text fields with bounded std::string helpers and shared size limits
- update menu entry duplication, updates, and banned menu initialization to clamp lengths safely
- adjust status bar layout builder to use the new string fields while keeping alignment and selection behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288bfb20c48328b5c68a209b7c7041)