### PR TITLE
Tighten stat bound checks

### DIFF
--- a/src/bg_local.h
+++ b/src/bg_local.h
@@ -260,8 +260,11 @@ enum player_stat_t {
 
 	STAT_MEDAL,
 
-	// don't use; just for verification
-	STAT_LAST
+// don't use; just for verification
+STAT_LAST
 };
 
-static_assert(STAT_LAST <= MAX_STATS + 1, "stats list overflow");
+constexpr size_t STAT_COUNT = static_cast<size_t>(STAT_LAST) + 1;
+
+static_assert(STAT_LAST < MAX_STATS, "stats list overflow");
+static_assert(STAT_COUNT <= MAX_STATS, "player_state_t::stats overflow");


### PR DESCRIPTION
## Summary
- tighten compile-time guards to ensure player stats stay within the MAX_STATS array limits
- compute the stat count from STAT_LAST and validate it against MAX_STATS for clarity

## Testing
- g++ -std=c++17 -I./src -fsyntax-only -x c++ src/bg_local.h


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928903fcbf08328a9d9eae7a7c2609c)