### PR TITLE
Fix menu text bounds and admin menu definition

### DIFF
--- a/src/g_menu.cpp
+++ b/src/g_menu.cpp
@@ -167,6 +167,13 @@ static void G_Menu_Admin_ChangeMatchLock(gentity_t *ent, menu_hnd_t *p) {
 	G_Menu_Admin_UpdateSettings(ent, p);
 }
 
+/*
+=============
+G_Menu_Admin_UpdateSettings
+
+Refreshes the admin settings menu entries to reflect the current values.
+=============
+*/
 void G_Menu_Admin_UpdateSettings(gentity_t *ent, menu_hnd_t *setmenu) {
 	int				  i = 2;
 	admin_settings_t *settings = (admin_settings_t *)setmenu->arg;
@@ -187,6 +194,8 @@ void G_Menu_Admin_UpdateSettings(gentity_t *ent, menu_hnd_t *setmenu) {
 	i++;
 
 	P_Menu_UpdateEntry(setmenu->entries + i, G_Fmt("match lock: {}", settings->match_lock ? "Yes" : "No").data(), MENU_ALIGN_LEFT, G_Menu_Admin_ChangeMatchLock);
+}
+
 const menu_t def_setmenu[] = {
 	P_Menu_CreateEntry("*Settings Menu", MENU_ALIGN_CENTER),
 	P_Menu_CreateEntry("", MENU_ALIGN_LEFT),

--- a/src/p_menu.h
+++ b/src/p_menu.h
@@ -43,7 +43,9 @@ inline std::string P_Menu_InitText(const char *src) {
 	if (!src)
 		return {};
 
-	const size_t length = std::strnlen(src, N - 1);
+	size_t length = 0;
+	while (length < N - 1 && src[length] != '\0')
+		length++;
 	return std::string(src, length);
 }
 


### PR DESCRIPTION
## Summary
- replace std::strnlen usage with a portable bounded length calculation in menu text initialization
- add documentation header and close admin menu update function before defining static menu entries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ad7e168408328b8fac866c00e8f4b)