### PR TITLE
Fix: powerup activation sound silent on default Q2RE ruleset

### DIFF
--- a/src/sgame/muffmode/mm_items_rules.cpp
+++ b/src/sgame/muffmode/mm_items_rules.cpp
@@ -415,7 +415,10 @@ void MM_OnPowerupItemRespawned(gentity_t *ent)
 
 bool MM_ShouldAnnouncePowerupUse()
 {
-	return RS(RS_MM) || RS(RS_Q3A) || RS(RS_VANILLA_PLUS);
+	// RS_Q2RE was omitted here, so on the default ruleset Use_Powerup_BroadcastMsg
+	// played no powerup activation sound at all -- e.g. the quad damage use sound
+	// (items/damage.wav) was silent on Q2RE deathmatch servers.
+	return RS(RS_Q2RE) || RS(RS_MM) || RS(RS_Q3A) || RS(RS_VANILLA_PLUS);
 }
 
 // [MuffMode] AutoDoc tech regen with per-ruleset/per-mod tuning (moved from sgame/entities/items.cpp).


### PR DESCRIPTION
Fixes #230.

## Problem
On the default `RS_Q2RE` ruleset, activating a powerup plays **no activation sound at all**. Most visible: the **quad damage** use sound (`items/damage.wav`) is silent on a stock-ruleset deathmatch server. Other powerup activations are silenced the same way.

## Root cause
`Use_Quad` and the other `Use_*` handlers route their activation sound through `Use_Powerup_BroadcastMsg` (`items.cpp`), which only plays when `MM_ShouldAnnouncePowerupUse()` returns true:

```cpp
return RS(RS_MM) || RS(RS_Q3A) || RS(RS_VANILLA_PLUS);
```

`g_ruleset` defaults to `RS_Q2RE` (`core/runtime.cpp`), which is not in that list — so the sound is never emitted on the default ruleset. Precache is fine (`item_registry.cpp` precaches `items/damage*.wav`); only playback is gated out.

## Fix
Add `RS_Q2RE` to the announce set. Builds clean (MSVC v14.44, Release x64, 0 warnings); verified in-game (quad activation sound + announcer restored on Q2RE).

## Note
This makes Q2RE use the same global announce path as the other rulesets, for all powerups. If you'd rather keep Q2RE announce-free and instead restore a stock local `CHAN_ITEM` sound, happy to rework — either way the current total silence looks unintended.
