### PR TITLE
Fix: match-stats menu shows all zeros (reads an unpopulated struct)

### DIFF
--- a/src/sgame/muffmode/mm_menu.cpp
+++ b/src/sgame/muffmode/mm_menu.cpp
@@ -475,7 +475,17 @@ void Update(gentity_t *ent)
 	if (!menu::GetEntries(ent, &entries, &num_entries))
 		return;
 
-	const auto &stats = ent->client->mstats;
+	// ent->client->mstats (client_match_stats_t) has no writers anywhere in the
+	// tree, so this screen always rendered zeros. Source the live per-match
+	// counters from resp.mstats[] via MS_Value. Field order matches the struct.
+	const client_match_stats_t stats = {
+		static_cast<uint32_t>(MS_Value(ent->client, MSTAT_DMG_DEALT)),
+		static_cast<uint32_t>(MS_Value(ent->client, MSTAT_DMG_RECEIVED)),
+		static_cast<uint32_t>(MS_Value(ent->client, MSTAT_SHOTS)),
+		static_cast<uint32_t>(MS_Value(ent->client, MSTAT_HITS)),
+		static_cast<uint32_t>(MS_Value(ent->client, MSTAT_KILLS_TOTAL)),
+		static_cast<uint32_t>(MS_Value(ent->client, MSTAT_DEATHS_TOTAL)),
+	};
 	MenuWriter writer{ entries, num_entries };
 	std::array<char, MAX_INFO_VALUE> value = {};
 	menu::CopyHostPlayerName(value);


### PR DESCRIPTION
## Problem
The match-stats menu (`muffmode::menu::stats::Update`) displays all zeros for kills/deaths/K-D, damage dealt/received/ratio, and shots/hits/accuracy — for every player, in every mode.

## Root cause
It reads `ent->client->mstats` (`client_match_stats_t`), which has **no writers anywhere in the source tree** (a full-tree search for assignments to `total_kills`/`total_shots`/`total_hits`/`total_dmg_*` returns nothing). The struct is zero-initialized and never populated.

The live per-match counters are maintained separately in `resp.mstats[]` (the `MSTAT_*` int array), written by `MS_Adjust` in `death.cpp`, `combat.cpp`, and `weapons.cpp`.

## Fix
Source the menu's values from `resp.mstats[]` via `MS_Value(MSTAT_*)` instead of the unpopulated struct. Field order matches `client_match_stats_t`, so the rest of the render logic is unchanged. Builds clean (MSVC v14.44, Release x64, 0 warnings).

The dead `client_match_stats_t` / `gclient_t::mstats` member can be removed as follow-up cleanup; kept in place here to keep the fix minimal.
