### PR TITLE
fix: g_dm_auto_join / g_dm_force_join never fire for human players

### DIFF
--- a/src/sgame/client/lifecycle.cpp
+++ b/src/sgame/client/lifecycle.cpp
@@ -679,8 +679,13 @@ static bool InitPlayerTeam(gentity_t *ent) {
 		return true;
 	}
 
-	// already initialised
-	if (ent->client->sess.team != TEAM_NONE)
+	// already initialised. ClientConnect pre-sets fresh deathmatch clients to
+	// TEAM_SPECTATOR before first spawn, which made this early-return swallow
+	// every human before the g_dm_force_join / g_dm_auto_join block below could
+	// run (the cvars were dead for humans). An uninitialised spectator is really
+	// a brand-new client awaiting first join, so let them fall through. [MuffMode]
+	if (ent->client->sess.team != TEAM_NONE &&
+		(ent->client->sess.initialised || ent->client->sess.team != TEAM_SPECTATOR))
 		return true;
 
 	ent->client->sess.team = TEAM_SPECTATOR;


### PR DESCRIPTION
## Bug

`g_dm_auto_join` and `g_dm_force_join` are dead cvars for human players.

`ClientConnect` pre-sets every fresh deathmatch client to `TEAM_SPECTATOR` before first spawn (its `InitPlayerTeam(ent)` call there is commented out):

https://github.com/DarkMatter-Productions/MuffMode/blob/45e4c9a/src/sgame/client/lifecycle.cpp#L1511-L1516

so by the time `InitPlayerTeam` runs at first spawn, the "already initialised" early-return (`sess.team != TEAM_NONE`) fires for **every human** and the `g_dm_force_join / g_dm_auto_join` block right below it is unreachable. Bots aren't affected because the bot manager assigns their team directly — which masks the bug in testing.

## Fix

Treat an **uninitialised spectator** as a brand-new client and let them fall through to the auto-join gate. `sess.initialised` only becomes `true` at the end of a successful `SetTeam` (including a deliberate spectator pick), so:

- fresh client (pre-set spectator, `initialised == false`) → falls through → auto-join applies as documented
- deliberate spectator (`initialised == true`) → early-returns as before, never force-joined
- `g_dm_auto_join 0` / `g_dm_force_join 0` (defaults) → behavior unchanged

Recursion via `SetTeam → ClientSpawn` is safe: `sess.team` and `sess.initialised` are both set before the nested spawn, so the inner `InitPlayerTeam` early-returns.

## Testing

- Release x64 build on top of `45e4c9a`: 0 warnings / 0 errors
- Verified in-game on a 16-slot FFA listen server (Q2 rerelease, Steam): with `g_dm_auto_join 1`, humans spawn straight into the match on connect and after map changes; with it unset, the join menu appears exactly as before; `team spectator` still works and spectators are not force-joined
